### PR TITLE
Problem: not loading selected gaslighter tests into memory 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
-max_line_length=80
+max_line_length=120
 
 [*.{nix,toml,capnp}]
 indent_style = space

--- a/src/bin/gaslighter/mod.rs
+++ b/src/bin/gaslighter/mod.rs
@@ -5,23 +5,70 @@ extern crate capnp;
 mod hierarchy_capnp;
 mod vm_capnp;
 
+use std::error::Error;
+use std::fs::File;
+use std::path::Path;
+use std::io::BufReader;
+
+use hierarchy_capnp::{directories, files};
+use capnp::{serialize, message};
+
+
 fn main() {
     let matches = clap_app!(gaslighter =>
         (version: "0.1.0")
         (author: "Stewart Mackenzie <setori88@gmail.com>")
         (about: "Gaslighter - Ethereum Virtual Machine tester.")
         (@arg CAPNPROTO_TYPECHECKED_TEST_BIN: -t --capnp_test_bin +takes_value "Absolute path to a typechecked binary compiled by the capnp tool. The source of this artefact is in the tests directory. Please run `$ capnp eval -b mod.capnp all >> test.bin` in the tests directory.")
-        (@arg ARTEFACT_DIRECTORY_ROOT: -a --artefact_dir +takes_value +required "Sets the root directory that contains the artefacts `libsputnikvm.so` and command line interface executable called `svm`")
+        (@arg TESTS_TO_RUN: -r --run_test +takes_value "The format is <directory>/<file>/<test> e.g. `--run_test arith/basic/add` will run the arith/basic/add test, `--run_test arith/basic/` will run all the tests in the tests/arith/basic.capnp file. Likewise `--run_test arith//` will run all the tests in all the files of the `arith` directory. Lastly `--run_test //` will run all the tests.")
     ).get_matches();
-    let test_dir = match matches.value_of("CAPNPROTO_TYPECHECKED_TEST_BIN") {
+    let capnp_test_bin = match matches.value_of("CAPNPROTO_TYPECHECKED_TEST_BIN") {
         Some(c) => c,
         None => "",
     };
-    println!("test_dir: {:?}", test_dir);
-    let artefact_dir = match matches.value_of("ARTEFACT_DIRECTORY_ROOT") {
+    let test_to_run = match matches.value_of("TESTS_TO_RUN") {
         Some(c) => c,
         None => "",
     };
-    println!("artefact_dir: {:?}", artefact_dir);
+    println!("capnp_test_bin: {:?}", capnp_test_bin);
+    let path = Path::new(capnp_test_bin);
+    let display = path.display();
+    let mut file = match File::open(&path) {
+        Err(_) => panic!("couldn't open {}", display),
+        Ok(file) => file,
+    };
 
+    let (dir_to_run, file_to_run, test_to_run) = test_scope(test_to_run.into());
+    let mut add_dir = false;
+    let mut add_file = false;
+    let mut add_test = false;
+    let mut contents = BufReader::new(file);
+    let tests_reader = serialize::read_message(&mut contents, message::ReaderOptions::new()).unwrap();
+    let mut tests_to_execute = Vec::new();
+    let top_level_tests = tests_reader.get_root::<directories::Reader>().unwrap();
+    for dir in top_level_tests.get_dirs().unwrap().iter() {
+        let dirname = dir.get_name().unwrap();
+        if dirname == dir_to_run || dir_to_run == "" { add_dir = true; }
+        else { add_dir = false; }
+        for file in dir.get_files().unwrap().iter() {
+            let filename = file.get_name().unwrap();
+            if filename == file_to_run || file_to_run == "" { add_file = true; }
+            else { add_file = false; }
+            for test in file.get_tests().unwrap().iter() {
+                let testname = test.get_name().unwrap();
+                if testname == test_to_run || test_to_run == "" {
+                    add_test = true;
+                    if add_dir && add_file && add_test {
+                        tests_to_execute.push(test);
+                    }
+                } else { add_test = false; }
+            }
+        }
+    }
+    println!("tests_to_execute length: {:?}", tests_to_execute.len() );
+}
+
+fn test_scope(test_to_run: String) -> (String, String, String) {
+    let vec: Vec<&str> = test_to_run.split("/").collect();
+    (vec[0].into(), vec[1].into(), vec[2].into())
 }


### PR DESCRIPTION
Solution: a *very* hacky switch filters a list of tests to
be executed against sputnikvm.

The selection process looks like this:

`--run-test arith/basic/add`

will run only the arith/basic/add test

`--run-test arith/basic/`

will run every test in the arith/basic.capnp file

`--run-test arith//`

will run every test in every capnp file in the arith directory

`--run-test ///`

will run every test in every capnp file in every directory