### PR TITLE
Jsonlighter and converting string to types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "merkle-sha3 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,8 +59,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "gcc"
 version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -90,6 +101,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +134,22 @@ dependencies = [
 name = "rustc-serialize"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -177,15 +209,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum capnp 0.8.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c42526d461a93d8a990f30ba51245b6b46c0ed1a761133d2e4fe5b47a9527a45"
 "checksum clap 2.23.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf1114886d7cde2d6448517161d7db8d681a9a1c09f7d210f0b0864e48195f6"
+"checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
+"checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum merkle-sha3 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5dd5529ec9d248c34cedc964ae0d9511c1efb700cd0121c61299cab95cea1868"
+"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "29dbdfd4b9df8ab31dec47c6087b7b13cbf4a776f335e4de8efba8288dda075b"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
+"checksum serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "231dfd55909400769e437326cfb4af8bec97c3dd56ab3d02df8ef5c7e00f179b"
+"checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,14 @@ path = "./src/bin/cli/mod.rs"
 name = "gaslighter"
 path = "./src/bin/gaslighter/mod.rs"
 
+[[bin]]
+name = "jsonlighter"
+path = "./src/bin/jsonlighter/mod.rs"
+
 [dependencies]
 clap = "2.22"
 log = "0.3"
 capnp = "0.8"
 rust-crypto = "^0.2"
 merkle-sha3 = "0.1"
+serde_json = "0.9"

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -4,40 +4,13 @@ extern crate clap;
 extern crate log;
 extern crate sputnikvm;
 
-use sputnikvm::Gas;
+use sputnikvm::{read_hex, Gas};
 use sputnikvm::vm::{Machine, FakeVectorMachine};
 
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use log::LogLevel;
-
-pub fn read_hex(s: &str) -> Option<Vec<u8>> {
-    let mut res = Vec::<u8>::new();
-
-    let mut cur = 0;
-    let mut len = 0;
-    for c in s.chars() {
-        len += 1;
-        let v_option = c.to_digit(16);
-        if v_option.is_none() {
-            return None;
-        }
-        let v = v_option.unwrap();
-        if len == 1 {
-            cur += v * 16;
-        } else { // len == 2
-            cur += v;
-        }
-        if len == 2 {
-            res.push(cur as u8);
-            cur = 0;
-            len = 0;
-        }
-    }
-
-    return Some(res);
-}
 
 fn main() {
     let matches = clap_app!(svm =>

--- a/src/bin/jsonlighter/mod.rs
+++ b/src/bin/jsonlighter/mod.rs
@@ -1,0 +1,63 @@
+#[macro_use]
+extern crate clap;
+extern crate serde_json;
+extern crate sputnikvm;
+
+use sputnikvm::{read_hex, Gas};
+use sputnikvm::vm::{Machine, FakeVectorMachine};
+
+use serde_json::{Value, Error};
+use std::fs::File;
+use std::path::Path;
+use std::io::BufReader;
+
+fn test_transaction(v: &Value) {
+    let current_coinbase = v["env"]["currentCoinbase"].as_str().unwrap();
+    let current_difficulty = v["env"]["currentDifficulty"].as_str().unwrap();
+    let current_gas_limit = v["env"]["currentGasLimit"].as_str().unwrap();
+    let current_number = v["env"]["currentNumber"].as_str().unwrap();
+    let current_timestamp = v["env"]["currentTimestamp"].as_str().unwrap();
+
+    let address = v["exec"]["address"].as_str().unwrap();
+    let caller = v["exec"]["caller"].as_str().unwrap();
+    let code = v["exec"]["code"].as_str().unwrap();
+    let data = v["exec"]["data"].as_str().unwrap();
+    let gas = v["exec"]["gas"].as_str().unwrap();
+    let gas_price = v["exec"]["gasPrice"].as_str().unwrap();
+    let origin = v["exec"]["origin"].as_str().unwrap();
+    let value = v["exec"]["value"].as_str().unwrap();
+
+    let out = v["out"].as_str().unwrap();
+
+    let ref pre_addresses = v["pre"];
+    let ref post_addresses = v["post"];
+
+    let code = read_hex(code).unwrap();
+    let data = read_hex(data).unwrap();
+    let gas = Gas::from_str(gas).unwrap();
+
+    let mut machine = FakeVectorMachine::new(code.as_ref(), data.as_ref(), gas);
+    machine.fire();
+
+    let out = read_hex(out).unwrap();
+    let out_ref: &[u8] = out.as_ref();
+    assert!(machine.return_values() == out_ref);
+
+}
+
+fn main() {
+    let app = clap_app!(jsonlighter =>
+        (version: "0.1.0")
+        (author: "SputnikVM Contributors")
+        (@arg FILE: -f --file +takes_value +required "ethereumproject/tests JSON file to run for this test")
+        (@arg TEST: -t --test +takes_value +required "test to run in the given file")
+    ).get_matches();
+
+    let path = Path::new(app.value_of("FILE").unwrap());
+    let file = File::open(&path).unwrap();
+    let reader = BufReader::new(file);
+    let json: Value = serde_json::from_reader(reader).unwrap();
+    let test = app.value_of("TEST").unwrap();
+
+    test_transaction(&json[test]);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub use utils::u256::U256;
 pub use utils::gas::Gas;
 pub use utils::hash::H256;
 pub use utils::address::Address;
+pub use utils::read_hex;

--- a/src/utils/address.rs
+++ b/src/utils/address.rs
@@ -1,4 +1,5 @@
 use utils::u256::U256;
+use utils::read_hex;
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub struct Address([u8; 20]);
@@ -33,6 +34,24 @@ impl From<U256> for Option<Address> {
             }
 
             Some(Address(a))
+        }
+    }
+}
+
+impl Address {
+    pub fn from_str(s: &str) -> Option<Address> {
+        let v = read_hex(s);
+        if v.is_none() { return None; }
+        let v = v.unwrap();
+
+        if v.len() == 20 {
+            let mut a = [0u8; 20];
+            for i in 0..20 {
+                a[i] = v[i];
+            }
+            Some(Address(a))
+        } else {
+            None
         }
     }
 }

--- a/src/utils/gas.rs
+++ b/src/utils/gas.rs
@@ -1,5 +1,6 @@
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use utils::u256::U256;
+use utils::read_hex;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Gas(isize);
@@ -7,6 +8,19 @@ pub struct Gas(isize);
 impl Gas {
     pub fn zero() -> Gas { Gas(0) }
     pub fn is_valid(&self) -> bool { self.0 >= 0 }
+
+    pub fn from_str(s: &str) -> Option<Gas> {
+        let v = read_hex(s);
+        if v.is_none() { return None; }
+        let v = v.unwrap();
+
+        let mut g: isize = 0;
+        for i in 0..v.len() {
+            let j = v.len() - i - 1;
+            g += (v[i] as isize) << (j * 8);
+        }
+        Some(Gas(g))
+    }
 }
 
 impl From<isize> for Gas {

--- a/src/utils/hash.rs
+++ b/src/utils/hash.rs
@@ -1,4 +1,5 @@
 use utils::u256::U256;
+use utils::read_hex;
 
 #[repr(C)]
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
@@ -13,5 +14,26 @@ impl Default for H256 {
 impl Into<U256> for H256 {
     fn into(self) -> U256 {
         U256::from(self.0.as_ref())
+    }
+}
+
+impl H256 {
+    pub fn from_str(s: &str) -> Option<H256> {
+        let v = read_hex(s);
+        if v.is_none() { return None; }
+        let v = v.unwrap();
+
+        if v.len() > 32 {
+            None
+        } else {
+            let mut a = [0u8; 32];
+
+            for i in 0..v.len() {
+                let j = i + (32 - v.len());
+                a[j] = v[i];
+            }
+
+            Some(H256(a))
+        }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,34 @@ pub mod u256;
 pub mod address;
 pub mod hash;
 pub mod gas;
+
+pub fn read_hex(s: &str) -> Option<Vec<u8>> {
+    if s.starts_with("0x") {
+        return read_hex(&s[2..s.len()]);
+    }
+
+    let mut res = Vec::<u8>::new();
+
+    let mut cur = 0;
+    let mut len = 0;
+    for c in s.chars() {
+        len += 1;
+        let v_option = c.to_digit(16);
+        if v_option.is_none() {
+            return None;
+        }
+        let v = v_option.unwrap();
+        if len == 1 {
+            cur += v * 16;
+        } else { // len == 2
+            cur += v;
+        }
+        if len == 2 {
+            res.push(cur as u8);
+            cur = 0;
+            len = 0;
+        }
+    }
+
+    return Some(res);
+}


### PR DESCRIPTION
Usage for jsonlighter (given `ethereumproject/tests` cloned to `../tests`):

```
RUST_BACKTRACE=1 cargo run --bin jsonlighter -- --file ../tests/VMTests/vmArithmeticTest.json --test add0
```

Right now all tests fails -- there seems to be some overflowing arithmetic tests, and blocks interface is not respected. We'll need to fix them before adding it to CI.