### PR TITLE
jsonlighter (nearly) complete checks and whole file test

### DIFF
--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -37,7 +37,7 @@ fn main() {
         None => "".as_bytes().into(),
     };
 
-    let mut machine = FakeVectorMachine::new(code.as_slice(), data, initial_gas);
+    let mut machine = FakeVectorMachine::fake(code.as_slice(), data, initial_gas);
     machine.fire();
     if log_enabled!(LogLevel::Info) {
         info!("gas used: {:?}", machine.used_gas());

--- a/src/bin/jsonlighter/blockchain.rs
+++ b/src/bin/jsonlighter/blockchain.rs
@@ -1,0 +1,120 @@
+use sputnikvm::{Gas, H256, U256, Address};
+use sputnikvm::vm::{Machine, VectorMachine};
+use sputnikvm::blockchain::Block;
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct JSONVectorBlock {
+    codes: HashMap<Address, Vec<u8>>,
+    balances: HashMap<Address, U256>,
+    storages: HashMap<Address, Vec<U256>>,
+
+    coinbase: Address,
+    timestamp: U256,
+    number: U256,
+    difficulty: U256,
+    gas_limit: Gas
+}
+
+impl JSONVectorBlock {
+    pub fn new(env: &Value) -> Self {
+        let current_coinbase = env["currentCoinbase"].as_str().unwrap();
+        let current_difficulty = env["currentDifficulty"].as_str().unwrap();
+        let current_gas_limit = env["currentGasLimit"].as_str().unwrap();
+        let current_number = env["currentNumber"].as_str().unwrap();
+        let current_timestamp = env["currentTimestamp"].as_str().unwrap();
+
+        JSONVectorBlock {
+            balances: HashMap::new(),
+            storages: HashMap::new(),
+            codes: HashMap::new(),
+
+            coinbase: Address::from_str(current_coinbase).unwrap(),
+            difficulty: U256::from_str(current_difficulty).unwrap(),
+            gas_limit: Gas::from_str(current_gas_limit).unwrap(),
+            number: U256::from_str(current_number).unwrap(),
+            timestamp: U256::from_str(current_timestamp).unwrap(),
+        }
+    }
+
+    pub fn set_account_code(&mut self, address: Address, code: &[u8]) {
+        self.codes.insert(address, code.into());
+    }
+
+    pub fn set_balance(&mut self, address: Address, balance: U256) {
+        self.balances.insert(address, balance);
+    }
+}
+
+impl Block for JSONVectorBlock {
+    fn account_code(&self, address: Address) -> Option<&[u8]> {
+        self.codes.get(&address).map(|s| s.as_ref())
+    }
+
+    fn create_account(&mut self, code: &[u8]) -> Option<Address> {
+        unimplemented!()
+    }
+
+    fn coinbase(&self) -> Address {
+        self.coinbase
+    }
+
+    fn balance(&self, address: Address) -> Option<U256> {
+        self.balances.get(&address).map(|s| *s)
+    }
+
+    fn timestamp(&self) -> U256 {
+        self.timestamp
+    }
+
+    fn number(&self) -> U256 {
+        self.number
+    }
+
+    fn difficulty(&self) -> U256 {
+        self.difficulty
+    }
+
+    fn gas_limit(&self) -> Gas {
+        self.gas_limit
+    }
+
+    fn account_storage(&self, address: Address, index: U256) -> U256 {
+        match self.storages.get(&address) {
+            None => U256::zero(),
+            Some(ref ve) => {
+                let index: usize = index.into();
+
+                match ve.get(index) {
+                    Some(&v) => v,
+                    None => U256::zero()
+                }
+            }
+        }
+    }
+
+    fn set_account_storage(&mut self, address: Address, index: U256, val: U256) {
+        if self.storages.get(&address).is_none() {
+            self.storages.insert(address, Vec::new());
+        }
+
+        let v = self.storages.get_mut(&address).unwrap();
+
+        let index: usize = index.into();
+
+        if v.len() <= index {
+            v.resize(index + 1, 0.into());
+        }
+
+        v[index] = val;
+    }
+
+    fn log(&mut self, address: Address, data: &[u8], topics: &[U256]) {
+        unimplemented!()
+    }
+
+    fn blockhash(&self, n: U256) -> H256 {
+        unimplemented!()
+    }
+}

--- a/src/bin/jsonlighter/mod.rs
+++ b/src/bin/jsonlighter/mod.rs
@@ -3,9 +3,14 @@ extern crate clap;
 extern crate serde_json;
 extern crate sputnikvm;
 
+mod blockchain;
+
+use blockchain::JSONVectorBlock;
+
 use sputnikvm::{read_hex, Gas, U256, Address};
-use sputnikvm::vm::{Machine, FakeVectorMachine};
+use sputnikvm::vm::{Machine, VectorMachine};
 use sputnikvm::blockchain::Block;
+use sputnikvm::transaction::{Transaction, VectorTransaction};
 
 use serde_json::{Value, Error};
 use std::fs::File;
@@ -13,45 +18,66 @@ use std::path::Path;
 use std::io::BufReader;
 
 fn test_transaction(v: &Value) {
-    let current_coinbase = v["env"]["currentCoinbase"].as_str().unwrap();
-    let current_difficulty = v["env"]["currentDifficulty"].as_str().unwrap();
-    let current_gas_limit = v["env"]["currentGasLimit"].as_str().unwrap();
-    let current_number = v["env"]["currentNumber"].as_str().unwrap();
-    let current_timestamp = v["env"]["currentTimestamp"].as_str().unwrap();
+    let mut block = JSONVectorBlock::new(&v["env"]);
 
-    let address = v["exec"]["address"].as_str().unwrap();
-    let caller = v["exec"]["caller"].as_str().unwrap();
-    let code = v["exec"]["code"].as_str().unwrap();
-    let data = v["exec"]["data"].as_str().unwrap();
-    let gas = v["exec"]["gas"].as_str().unwrap();
-    let gas_price = v["exec"]["gasPrice"].as_str().unwrap();
-    let origin = v["exec"]["origin"].as_str().unwrap();
-    let value = v["exec"]["value"].as_str().unwrap();
+    let current_gas_limit = Gas::from_str(v["env"]["currentGasLimit"].as_str().unwrap()).unwrap();
+    let address = Address::from_str(v["exec"]["address"].as_str().unwrap()).unwrap();
+    let caller = Address::from_str(v["exec"]["caller"].as_str().unwrap()).unwrap();
+    let code = read_hex(v["exec"]["code"].as_str().unwrap()).unwrap();
+    let data = read_hex(v["exec"]["data"].as_str().unwrap()).unwrap();
+    let gas = Gas::from_str(v["exec"]["gas"].as_str().unwrap()).unwrap();
+    let gas_price = Gas::from_str(v["exec"]["gasPrice"].as_str().unwrap()).unwrap();
+    let origin = Address::from_str(v["exec"]["origin"].as_str().unwrap()).unwrap();
+    let value = U256::from_str(v["exec"]["value"].as_str().unwrap()).unwrap();
+
+    let transaction = VectorTransaction::message_call(
+        caller, address, value, data.as_ref(), current_gas_limit
+    );
 
     let out = v["out"].as_str().unwrap();
 
     let ref pre_addresses = v["pre"];
-    let ref post_addresses = v["post"];
 
-    let code = read_hex(code).unwrap();
-    let data = read_hex(data).unwrap();
-    let gas = Gas::from_str(gas).unwrap();
+    for (address, data) in pre_addresses.as_object().unwrap() {
+        let address = Address::from_str(address.as_str()).unwrap();
+        let balance = U256::from_str(data["balance"].as_str().unwrap()).unwrap();
+        let code = read_hex(data["code"].as_str().unwrap()).unwrap();
 
-    let mut machine = FakeVectorMachine::new(code.as_ref(), data.as_ref(), gas);
+        block.set_account_code(address, code.as_ref());
+        block.set_balance(address, balance);
+
+        let storage = data["storage"].as_object().unwrap();
+        for (index, value) in storage {
+            let index = U256::from_str(index.as_str()).unwrap();
+            let value = U256::from_str(value.as_str().unwrap()).unwrap();
+            block.set_account_storage(address, index, value);
+        }
+    }
+
+    let mut machine: VectorMachine<JSONVectorBlock, Box<JSONVectorBlock>> =
+                                   VectorMachine::new(code.as_ref(), data.as_ref(), gas,
+                                                      transaction, Box::new(block));
     machine.fire();
 
     let out = read_hex(out).unwrap();
     let out_ref: &[u8] = out.as_ref();
     assert!(machine.return_values() == out_ref);
 
+    let ref post_addresses = v["post"];
+
     for (address, data) in post_addresses.as_object().unwrap() {
         let address = Address::from_str(address.as_str()).unwrap();
+        let balance = U256::from_str(data["balance"].as_str().unwrap()).unwrap();
+        let code = read_hex(data["code"].as_str().unwrap()).unwrap();
+
+        assert!(Some(code.as_ref()) == machine.block().account_code(address));
+        assert!(Some(balance) == machine.block().balance(address));
+
         let storage = data["storage"].as_object().unwrap();
         for (index, value) in storage {
             let index = U256::from_str(index.as_str()).unwrap();
             let value = U256::from_str(value.as_str().unwrap()).unwrap();
-            // TODO: change Address::default() to the actual address
-            assert!(value == machine.block().account_storage(Address::default(), index));
+            assert!(value == machine.block().account_storage(address, index));
         }
     }
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -6,18 +6,23 @@ use utils::hash::H256;
 use std::collections::HashMap;
 
 pub trait Block {
+    // Account information
     fn account_code(&self, address: Address) -> Option<&[u8]>;
-    fn coinbase(&self) -> Address;
     fn balance(&self, address: Address) -> Option<U256>;
+    fn account_storage(&self, address: Address, index: U256) -> U256;
+    fn set_account_storage(&mut self, address: Address, index: U256, val: U256);
+
+    // Block information
+    fn coinbase(&self) -> Address;
     fn timestamp(&self) -> U256;
     fn number(&self) -> U256;
     fn difficulty(&self) -> U256;
     fn gas_limit(&self) -> Gas;
-    fn create_account(&mut self, code: &[u8]) -> Option<Address>;
-    fn account_storage(&self, address: Address, index: U256) -> U256;
-    fn set_account_storage(&mut self, address: Address, index: U256, val: U256);
-    fn log(&mut self, address: Address, data: &[u8], topics: &[U256]);
     fn blockhash(&self, n: U256) -> H256;
+
+    // Actions
+    fn log(&mut self, address: Address, data: &[u8], topics: &[U256]);
+    fn create_account(&mut self, code: &[u8]) -> Option<Address>;
 }
 
 pub struct FakeVectorBlock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub extern fn evaluate(ptr: *mut std::vec::Vec<capnp::Word>) {
     }
     let gas = msg_reader.get_input().expect("failed3").get_initial_gas();
 
-    let mut machine = FakeVectorMachine::new(
+    let mut machine = FakeVectorMachine::fake(
         code_vec.as_slice()
         , data_vec.as_slice()
         , Gas::from(gas as isize));

--- a/src/vm/machine.rs
+++ b/src/vm/machine.rs
@@ -75,6 +75,22 @@ pub struct VectorMachine<B0, BR> {
     _block_marker: PhantomData<B0>,
 }
 
+impl<B0: Block, BR: AsRef<B0> + AsMut<B0>> VectorMachine<B0, BR> {
+    pub fn new(code: &[u8], data: &[u8], gas_limit: Gas,
+               transaction: VectorTransaction, block: BR) -> Self {
+        VectorMachine {
+            pc: VectorPC::new(code),
+            memory: VectorMemory::new(),
+            stack: VectorStack::new(),
+            transaction: transaction,
+            return_values: Vec::new(),
+            block: Some(block),
+            used_gas: Gas::zero(),
+            _block_marker: PhantomData,
+        }
+    }
+}
+
 impl<B0: Block, BR: AsRef<B0> + AsMut<B0>> Machine for VectorMachine<B0, BR> {
     type P = VectorPC;
     type M = VectorMemory;
@@ -180,17 +196,10 @@ impl<B0: Block, BR: AsRef<B0> + AsMut<B0>> Machine for VectorMachine<B0, BR> {
 pub type FakeVectorMachine = VectorMachine<FakeVectorBlock, Box<FakeVectorBlock>>;
 
 impl FakeVectorMachine {
-    pub fn new(code: &[u8], data: &[u8], gas_limit: Gas) -> FakeVectorMachine {
-        VectorMachine {
-            pc: VectorPC::new(code),
-            memory: VectorMemory::new(),
-            stack: VectorStack::new(),
-            transaction: VectorTransaction::message_call(Address::default(), Address::default(),
-                                                         U256::zero(), data, gas_limit),
-            return_values: Vec::new(),
-            block: Some(Box::new(FakeVectorBlock::new())),
-            used_gas: Gas::zero(),
-            _block_marker: PhantomData,
-        }
+    pub fn fake(code: &[u8], data: &[u8], gas_limit: Gas) -> FakeVectorMachine {
+        VectorMachine::new(code, data, gas_limit,
+                           VectorTransaction::message_call(Address::default(), Address::default(),
+                                                           U256::zero(), data, gas_limit),
+                           Box::new(FakeVectorBlock::new()))
     }
 }


### PR DESCRIPTION
See commits for details. Usage:

```
RUST_BACKTRACE=1 cargo run --bin jsonlighter -- --file ../tests/VMTests/vmArithmeticTest.json
```

Currently add0 to add4 passes, the output is:

```
Testing add0 ... OK
Testing add1 ... OK
Testing add2 ... OK
Testing add3 ... OK
Testing add4 ... OK
Testing addmod0 ...thread 'main' panicked at 'attempt to subtract with overflow', src/utils/u256.rs:296
```