### PR TITLE
AccountState and Context refactor

### DIFF
--- a/src/bin/gaslighter/crat.rs
+++ b/src/bin/gaslighter/crat.rs
@@ -57,7 +57,7 @@ pub fn test_transaction(name: &str, v: &Value, debug: bool) -> bool {
 pub fn debug_transaction(v: &Value) {
     let mut block = create_block(v);
     let mut machine = create_machine(v, &block);
-    let owner = machine.owner();
+    let owner = machine.owner().unwrap();
     machine.commit(block.request_account(owner));
     let mut rl = Editor::<()>::new();
 

--- a/src/bin/gaslighter/json/blockchain.rs
+++ b/src/bin/gaslighter/json/blockchain.rs
@@ -227,7 +227,7 @@ pub fn create_context(v: &Value) -> Context {
         caller: caller,
         code: code,
         data: data,
-        gas: gas,
+        gas_limit: gas,
         gas_price: gas_price,
         origin: origin,
         value: value,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod bigint;
 pub mod address;
 pub mod gas;
 pub mod opcode;
+pub mod rlp;
 
 #[derive(Debug)]
 pub enum ParseHexError {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,7 +2,7 @@ pub mod bigint;
 pub mod address;
 pub mod gas;
 pub mod opcode;
-pub mod rlp;
+// pub mod rlp;
 
 #[derive(Debug)]
 pub enum ParseHexError {

--- a/src/utils/rlp.rs
+++ b/src/utils/rlp.rs
@@ -1,0 +1,62 @@
+//! RLP (Recursive Length Prefix) is to encode arbitrarily nested arrays of binary data,
+//! RLP is the main encoding method used to serialize objects in Ethereum.
+//!
+//! See [RLP spec](https://github.com/ethereumproject/wiki/wiki/RLP)
+
+// Copied from https://github.com/ethereumproject/emerald-rs/blob/master/src/util/rlp.rs
+
+/// The `WriteRLP` trait is used to specify functionality of serializing data to RLP bytes
+pub trait WriteRLP {
+    /// Writes itself as RLP bytes into specified buffer
+    fn write_rlp(&self, buf: &mut Vec<u8>);
+}
+
+/// A list serializable to RLP
+pub struct RLPList {
+    tail: Vec<u8>,
+}
+
+impl RLPList {
+    /// Start with provided vector
+    pub fn from_slice<T: WriteRLP>(items: &[T]) -> RLPList {
+        let mut start = RLPList { tail: Vec::new() };
+        for i in items {
+            start.push(i)
+        }
+        start
+    }
+
+    /// Add an item to the list
+    pub fn push<T: WriteRLP + ?Sized>(&mut self, item: &T) {
+        item.write_rlp(&mut self.tail);
+    }
+}
+
+impl Default for RLPList {
+    fn default() -> RLPList {
+        RLPList { tail: Vec::new() }
+    }
+}
+
+impl WriteRLP for [u8] {
+    fn write_rlp(&self, buf: &mut Vec<u8>) {
+        let len = self.len();
+        if len <= 55 {
+            // Otherwise, if a string is 0-55 bytes long, the RLP encoding consists of a single byte
+            // with value 0x80 plus the length of the string followed by the string. The range of
+            // the first byte is thus [0x80, 0xb7].
+            buf.push(0x80 + len as u8);
+            buf.extend_from_slice(self);
+        } else {
+            // If a string is more than 55 bytes long, the RLP encoding consists of a single byte
+            // with value 0xb7 plus the length in bytes of the length of the string in binary form,
+            // followed by the length of the string, followed by the string. For example, a
+            // length-1024 string would be encoded as \xb9\x04\x00 followed by the string. The
+            // range of the first byte is thus [0xb8, 0xbf].
+            let len_bytes = bytes_count(len);
+            buf.push(0xb7 + len_bytes);
+            buf.extend_from_slice(&to_bytes(len as u64, len_bytes));
+            buf.extend_from_slice(self);
+        }
+    }
+}

--- a/src/vm/account.rs
+++ b/src/vm/account.rs
@@ -5,7 +5,20 @@ use utils::bigint::{M256, U256};
 
 use super::{ExecutionResult, ExecutionError};
 
-#[derive(Debug, Clone)]
+pub enum AccountCommitment<S> {
+    Full {
+        nonce: M256,
+        address: Address,
+        balance: U256,
+        storage: S,
+        code: Vec<u8>,
+    },
+    Code {
+        address: Address,
+        code: Vec<u8>,
+    },
+}
+
 pub enum Account<S> {
     Full {
         nonce: M256,
@@ -13,14 +26,26 @@ pub enum Account<S> {
         balance: U256,
         storage: S,
         code: Vec<u8>,
-        appending_logs: Vec<Log>,
+        appending_logs: Vec<u8>,
     },
-    Code {
-        address: Address,
-        code: Vec<u8>,
-    },
-    Remove(Address),
-    Topup(Address, U256),
+    IncreaseBalance(Address, U256),
+    DecreaseBalance(Address, U256),
+}
+
+pub struct AccountState<S> {
+    accounts: hash_map::HashMap<Address, Account<S>>,
+    codes: hash_map::HashMap<Address, Vec<u8>>,
+}
+
+impl<S: Storage> AccountState<S> {
+    pub fn commit(commitment: AccountCommitment<S>) -> CommitError<()> {
+
+    }
+
+    // Getter: code, nonce, balance, storage, storage_mut
+    // Modifier: increase_balance, decrease_balance
+    // Modifier: set_nonce
+    // Modifier: append_log
 }
 
 impl<S: Storage> Account<S> {

--- a/src/vm/account.rs
+++ b/src/vm/account.rs
@@ -8,6 +8,7 @@ use super::{ExecutionResult, ExecutionError};
 #[derive(Debug, Clone)]
 pub enum Account<S> {
     Full {
+        nonce: M256,
         address: Address,
         balance: U256,
         storage: S,
@@ -27,14 +28,11 @@ impl<S: Storage> Account<S> {
         match self {
             &Account::Full {
                 address: address,
-                balance: _,
-                storage: _,
-                code: _,
-                appending_logs: _,
+                ..
             } => address,
             &Account::Code {
                 address: address,
-                code: _,
+                ..
             } => address,
             &Account::Remove(address) => address,
             &Account::Topup(address, _) => address,

--- a/src/vm/cost.rs
+++ b/src/vm/cost.rs
@@ -55,7 +55,7 @@ fn sstore_cost<M: Memory + Default,
                S: Storage + Default>(machine: &Machine<M, S>) -> ExecutionResult<Gas> {
     let index = machine.stack().peek(0)?;
     let value = machine.stack().peek(1)?;
-    let address = machine.owner();
+    let address = machine.owner()?;
 
     if value != M256::zero() && machine.account_storage(address)?.read(index)? == M256::zero() {
         Ok(G_SSET.into())
@@ -298,7 +298,7 @@ pub fn gas_refund<M: Memory + Default,
         Opcode::SSTORE => {
             let index = machine.stack().peek(0)?;
             let value = machine.stack().peek(1)?;
-            let address = machine.owner();
+            let address = machine.owner()?;
 
             if value == M256::zero() && machine.account_storage(address)?.read(index)? != M256::zero() {
                 Ok(Gas::from(R_SCLEAR))

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -78,6 +78,7 @@ pub struct Machine<M, S> {
     valid_pc: bool,
     used_gas: Gas,
     refunded_gas: Gas,
+    depth: usize,
 
     homestead: bool,
     eip150: bool,
@@ -86,6 +87,10 @@ pub struct Machine<M, S> {
 
 impl<M: Memory + Default, S: Storage> Machine<M, S> {
     pub fn new(transaction: Transaction, block: BlockHeader) -> Self {
+        Machine::with_depth(transaction, block, 1)
+    }
+
+    pub fn with_depth(transaction: Transaction, block: BlockHeader, depth: usize) -> Self {
         Self {
             pc: PC::default(),
             memory: M::default(),
@@ -99,6 +104,7 @@ impl<M: Memory + Default, S: Storage> Machine<M, S> {
             valid_pc: false,
             used_gas: Gas::zero(),
             refunded_gas: Gas::zero(),
+            depth: depth,
 
             homestead: false,
             eip150: false,

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -219,7 +219,7 @@ impl<M: Memory + Default, S: Storage + Default> Machine<M, S> {
     }
 
     pub fn available_gas(&self) -> Gas {
-        self.context.gas - self.used_gas
+        self.context.gas_limit - self.used_gas
     }
 
 

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3,15 +3,18 @@ mod pc;
 mod memory;
 mod params;
 mod account;
+mod storage;
 mod cost;
 mod run;
 
 pub use self::memory::{Memory, SeqMemory};
 pub use self::stack::Stack;
 pub use self::pc::PC;
-pub use self::params::{BlockHeader, Transaction};
-pub use self::account::{Account, Storage, HashMapStorage, Log};
+pub use self::params::{BlockHeader, Context, Patch, Log};
+pub use self::account::{Account, AccountCommitment};
+pub use self::storage::{Storage, HashMapStorage};
 
+use self::account::AccountState;
 use self::cost::{gas_cost, gas_refund, CostAggregrator};
 use self::run::run_opcode;
 use std::collections::hash_map;
@@ -49,13 +52,28 @@ pub type CommitResult<T> = ::std::result::Result<T, CommitError>;
 
 pub type SeqMachine = Machine<SeqMemory, HashMapStorage>;
 
-pub trait VM<S> {
-    fn step(&mut self) -> ExecutionResult<()>,
-    fn peek_cost(&self) -> ExecutionResult<Gas>,
-    fn fire(&mut self) -> ExecutionResult<()>,
+pub trait VM<S: Storage> {
+    fn step(&mut self) -> ExecutionResult<()>;
+    fn peek_cost(&self) -> ExecutionResult<Gas>;
+    fn fire(&mut self) -> ExecutionResult<()> {
+        loop {
+            let result = self.step();
 
-    fn commit_account(commitment: AccountCommitment<S>) -> CommitResult<()>;
-    fn commit_blockhash(number: M256, hash: M256) -> CommitResult<()>;
+            if result.is_err() {
+                match result.err().unwrap() {
+                    ExecutionError::Stopped => return Ok(()),
+                    err => return Err(err),
+                }
+            }
+        }
+    }
+
+    fn commit_account(&mut self, commitment: AccountCommitment<S>) -> CommitResult<()>;
+    fn commit_blockhash(&mut self, number: M256, hash: M256) -> CommitResult<()>;
+    fn accounts(&self) -> hash_map::Values<Address, Account<S>>;
+    fn appending_logs(&self) -> &[Log];
+
+    fn patch(&self) -> Patch;
 }
 
 pub struct Machine<M, S> {
@@ -65,156 +83,52 @@ pub struct Machine<M, S> {
     cost_aggregrator: CostAggregrator,
     return_values: Vec<u8>,
 
-    context: ExecutionContext,
+    context: Context,
     block: BlockHeader,
 
-    account_state: AccountState,
+    account_state: AccountState<S>,
     blockhashes: hash_map::HashMap<M256, M256>,
+    appending_logs: Vec<Log>,
 
     used_gas: Gas,
     refunded_gas: Gas,
 
-    homestead: bool,
-    eip150: bool,
-    eip160: bool,
-}
-
-impl<M: Memory + Default, S: Storage> ContextMachine<M, S> {
-    pub fn new(context: Context, block: BlockHeader) -> Self {
-        Self {
-            pc: PC::default(),
-            memory: M::default(),
-            stack: Stack::default(),
-            transaction: transaction,
-            block: block,
-            cost_aggregrator: CostAggregrator::default(),
-            return_values: Vec::new(),
-            accounts: hash_map::HashMap::new(),
-            blockhashes: hash_map::HashMap::new(),
-            valid_pc: false,
-            used_gas: Gas::zero(),
-            refunded_gas: Gas::zero(),
-            depth: depth,
-
-            homestead: false,
-            eip150: false,
-            eip160: false,
-        }
-    }
+    patch: Patch,
 }
 
 impl<M: Memory + Default, S: Storage + Default> Machine<M, S> {
-    pub fn pc(&self) -> Option<&PC> {
-        if self.valid_pc {
-            Some(&self.pc)
-        } else {
-            None
+    pub fn new(context: Context, block: BlockHeader) -> Self {
+        Self {
+            pc: PC::new(context.code.as_slice()),
+            memory: M::default(),
+            stack: Stack::default(),
+            cost_aggregrator: CostAggregrator::default(),
+            return_values: Vec::new(),
+
+            context: context,
+            block: block,
+
+            account_state: AccountState::default(),
+            blockhashes: hash_map::HashMap::new(),
+            appending_logs: Vec::new(),
+
+            used_gas: Gas::zero(),
+            refunded_gas: Gas::zero(),
+
+            patch: Patch::None,
         }
     }
+}
 
-    pub fn memory(&self) -> &M {
-        &self.memory
-    }
-
-    pub fn stack(&self) -> &Stack {
-        &self.stack
-    }
-
-    pub fn transaction(&self) -> &Transaction {
-        &self.transaction
-    }
-
-    pub fn block(&self) -> &BlockHeader {
-        &self.block
-    }
-
-    pub fn accounts(&self) -> hash_map::Values<Address, Account<S>> {
-        self.accounts.values()
-    }
-
-    pub fn return_values(&self) -> &[u8] {
-        self.return_values.as_slice()
-    }
-
-    pub fn active_memory_len(&self) -> M256 {
-        self.cost_aggregrator.active_memory_len()
-    }
-
-    pub fn owner(&self) -> ExecutionResult<Address> {
-        Ok(match self.transaction {
-            Transaction::MessageCall {
-                to: to,
-                ..
-            } => to,
-            Transaction::ContractCreation {
-                ..
-            } => unimplemented!(),
-        })
-    }
-
-    pub fn available_gas(&self) -> Gas {
-        self.transaction.gas_limit() - self.used_gas
-    }
-
-
-    pub fn homestead(&self) -> bool {
-        self.homestead
-    }
-
-    pub fn set_homestead(&mut self, val: bool) {
-        self.homestead = val;
-    }
-
-    pub fn eip150(&self) -> bool {
-        self.eip150
-    }
-
-    pub fn set_eip150(&mut self, val: bool) {
-        self.eip150 = val;
-    }
-
-    pub fn eip160(&self) -> bool {
-        self.eip160
-    }
-
-    pub fn set_eip160(&mut self, val: bool) {
-        self.eip160 = val;
-    }
-
-
-    pub fn commit_blockhash(&mut self, number: M256, hash: M256) -> Result<(), CommitError> {
-        if self.blockhashes.contains_key(&number) {
-            return Err(CommitError::AlreadyCommitted);
-        }
-
-        self.blockhashes.insert(number, hash);
-        Ok(())
-    }
-
-    fn blockhash(&mut self, number: M256) -> ExecutionResult<M256> {
-        match self.blockhashes.get(&number) {
-            Some(val) => Ok(*val),
-            None => Err(ExecutionError::RequireBlockhash(number)),
-        }
-    }
-
-
-    pub fn peek_cost(&self) -> ExecutionResult<Gas> {
-        if !self.valid_pc {
-            return Err(ExecutionError::RequireAccount(self.owner()?));
-        }
-
+impl<M: Memory + Default, S: Storage + Default> VM<S> for Machine<M, S> {
+    fn peek_cost(&self) -> ExecutionResult<Gas> {
         let opcode = self.pc.peek_opcode()?;
         let aggregrator = self.cost_aggregrator;
         let (gas, agg) = gas_cost(opcode, &self, aggregrator)?;
         Ok(gas)
     }
 
-    pub fn step(&mut self) -> ExecutionResult<()> {
-        if !self.valid_pc {
-            return Err(ExecutionError::RequireAccount(self.owner()?));
-        }
-
+    fn step(&mut self) -> ExecutionResult<()> {
         begin_rescuable!(self, &mut Self, __);
         if self.pc.stopped() {
             trr!(Err(ExecutionError::Stopped), __);
@@ -245,16 +159,78 @@ impl<M: Memory + Default, S: Storage + Default> Machine<M, S> {
         Ok(())
     }
 
-    pub fn fire(&mut self) -> ExecutionResult<()> {
-        loop {
-            let result = self.step();
+    fn commit_account(&mut self, commitment: AccountCommitment<S>) -> CommitResult<()> {
+        self.account_state.commit(commitment)
+    }
 
-            if result.is_err() {
-                match result.err().unwrap() {
-                    ExecutionError::Stopped => return Ok(()),
-                    err => return Err(err),
-                }
-            }
+    fn commit_blockhash(&mut self, number: M256, hash: M256) -> CommitResult<()> {
+        if self.blockhashes.contains_key(&number) {
+            return Err(CommitError::AlreadyCommitted);
         }
+
+        self.blockhashes.insert(number, hash);
+        Ok(())
+    }
+
+    fn accounts(&self) -> hash_map::Values<Address, Account<S>> {
+        self.account_state.accounts()
+    }
+
+    fn appending_logs(&self) -> &[Log] {
+        self.appending_logs.as_slice()
+    }
+
+    fn patch(&self) -> Patch {
+        self.patch
+    }
+}
+
+impl<M: Memory + Default, S: Storage + Default> Machine<M, S> {
+    pub fn pc(&self) -> &PC {
+        &self.pc
+    }
+
+    pub fn memory(&self) -> &M {
+        &self.memory
+    }
+
+    pub fn stack(&self) -> &Stack {
+        &self.stack
+    }
+
+    pub fn context(&self) -> &Context {
+        &self.context
+    }
+
+    pub fn block(&self) -> &BlockHeader {
+        &self.block
+    }
+
+    pub fn accounts(&self) -> hash_map::Values<Address, Account<S>> {
+        self.account_state.accounts()
+    }
+
+    pub fn return_values(&self) -> &[u8] {
+        self.return_values.as_slice()
+    }
+
+    pub fn active_memory_len(&self) -> M256 {
+        self.cost_aggregrator.active_memory_len()
+    }
+
+    pub fn available_gas(&self) -> Gas {
+        self.context.gas - self.used_gas
+    }
+
+
+    fn blockhash(&mut self, number: M256) -> ExecutionResult<M256> {
+        match self.blockhashes.get(&number) {
+            Some(val) => Ok(*val),
+            None => Err(ExecutionError::RequireBlockhash(number)),
+        }
+    }
+
+    fn append_log(&mut self, log: Log) {
+        self.appending_logs.push(log);
     }
 }

--- a/src/vm/params.rs
+++ b/src/vm/params.rs
@@ -10,6 +10,18 @@ pub struct BlockHeader {
     pub gas_limit: Gas
 }
 
+pub struct ExecutionContext {
+    address,
+    caller,
+    code,
+    data,
+    gas,
+    gas_price,
+    origin,
+    value,
+    depth,
+} // Transaction => ExecutionContext
+
 pub enum Transaction {
     MessageCall {
         gas_price: Gas,

--- a/src/vm/params.rs
+++ b/src/vm/params.rs
@@ -2,6 +2,7 @@ use utils::gas::Gas;
 use utils::address::Address;
 use utils::bigint::{M256, U256};
 
+#[derive(Debug, Clone)]
 pub struct BlockHeader {
     pub coinbase: Address,
     pub timestamp: M256,
@@ -10,101 +11,21 @@ pub struct BlockHeader {
     pub gas_limit: Gas
 }
 
-pub struct ExecutionContext {
-    address,
-    caller,
-    code,
-    data,
-    gas,
-    gas_price,
-    origin,
-    value,
-    depth,
-} // Transaction => ExecutionContext
-
-pub enum Transaction {
-    MessageCall {
-        gas_price: Gas,
-        gas_limit: Gas,
-        to: Address,
-        originator: Address,
-        caller: Address,
-        value: M256,
-        data: Vec<u8>,
-    },
-    ContractCreation {
-        gas_price: Gas,
-        gas_limit: Gas,
-        originator: Address,
-        caller: Address,
-        value: M256,
-        init: Vec<u8>
-    }
+#[derive(Debug, Clone)]
+pub struct Context {
+    pub address: Address,
+    pub caller: Address,
+    pub code: Vec<u8>,
+    pub data: Vec<u8>,
+    pub gas: Gas,
+    pub gas_price: Gas,
+    pub origin: Address,
+    pub value: M256,
+    pub depth: usize,
 }
 
-impl Transaction {
-    pub fn gas_limit(&self) -> Gas {
-        match self {
-            &Transaction::MessageCall {
-                gas_limit: gas_limit,
-                ..
-            } => gas_limit,
-            &Transaction::ContractCreation {
-                gas_limit: gas_limit,
-                ..
-            } => gas_limit,
-        }
-    }
-
-    pub fn value(&self) -> M256 {
-        match self {
-            &Transaction::MessageCall {
-                value: value,
-                ..
-            } => value,
-            &Transaction::ContractCreation {
-                value: value,
-                ..
-            } => value,
-        }
-    }
-
-    pub fn caller(&self) -> Address {
-        match self {
-            &Transaction::MessageCall {
-                caller: caller,
-                ..
-            } => caller,
-            &Transaction::ContractCreation {
-                caller: caller,
-                ..
-            } => caller,
-        }
-    }
-
-    pub fn originator(&self) -> Address {
-        match self {
-            &Transaction::MessageCall {
-                originator: originator,
-                ..
-            } => originator,
-            &Transaction::ContractCreation {
-                originator: originator,
-                ..
-            } => originator,
-        }
-    }
-
-    pub fn gas_price(&self) -> Gas {
-        match self {
-            &Transaction::MessageCall {
-                gas_price: gas_price,
-                ..
-            } => gas_price,
-            &Transaction::ContractCreation {
-                gas_price: gas_price,
-                ..
-            } => gas_price,
-        }
-    }
+#[derive(Debug, Clone)]
+pub struct Log {
+    pub data: Vec<u8>,
+    pub topics: Vec<M256>,
 }

--- a/src/vm/params.rs
+++ b/src/vm/params.rs
@@ -17,7 +17,7 @@ pub struct Context {
     pub caller: Address,
     pub code: Vec<u8>,
     pub data: Vec<u8>,
-    pub gas: Gas,
+    pub gas_limit: Gas,
     pub gas_price: Gas,
     pub origin: Address,
     pub value: M256,

--- a/src/vm/params.rs
+++ b/src/vm/params.rs
@@ -26,6 +26,38 @@ pub struct Context {
 
 #[derive(Debug, Clone)]
 pub struct Log {
+    pub address: Address,
     pub data: Vec<u8>,
     pub topics: Vec<M256>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Patch {
+    None,
+    Homestead,
+    EIP150,
+    EIP160
+}
+
+impl Patch {
+    pub fn homestead(&self) -> bool {
+        match self {
+            &Patch::None => false,
+            _ => true,
+        }
+    }
+
+    pub fn eip150(&self) -> bool {
+        match self {
+            &Patch::None | &Patch::Homestead => false,
+            _ => true,
+        }
+    }
+
+    pub fn eip160(&self) -> bool {
+        match self {
+            &Patch::None | &Patch::Homestead | &Patch::EIP150 => false,
+            _ => true,
+        }
+    }
 }

--- a/src/vm/run.rs
+++ b/src/vm/run.rs
@@ -283,8 +283,10 @@ pub fn run_opcode<M: Memory + Default,
         Opcode::ADDRESS => {
             will_pop_push!(machine, 0, 1);
 
-            let address = machine.owner();
+            begin_rescuable!(machine, &mut Machine<M, S>, __);
+            let address = trr!(machine.owner(), __);
             machine.stack.push(address.into()).unwrap();
+            end_rescuable!(__);
         },
 
         Opcode::BALANCE => {
@@ -647,7 +649,7 @@ pub fn run_opcode<M: Memory + Default,
                 machine.stack.push(op1).unwrap();
             }, __);
 
-            let from = machine.owner();
+            let from = trr!(machine.owner(), __);
             let val = trr!(machine.account_storage(from).and_then(|storage| storage.read(op1)), __);
             machine.stack.push(val).unwrap();
         },
@@ -663,7 +665,7 @@ pub fn run_opcode<M: Memory + Default,
                 machine.stack.push(op1).unwrap();
             }, __);
 
-            let from = machine.owner();
+            let from = trr!(machine.owner(), __);
             trr!(machine.account_storage_mut(from).and_then(|storage| storage.write(op1, op2)), __);
             end_rescuable!(__);
         }
@@ -761,7 +763,7 @@ pub fn run_opcode<M: Memory + Default,
             will_pop_push!(machine, v+2, 0);
 
             begin_rescuable!(machine, &mut Machine<M, S>, __);
-            let address = machine.owner();
+            let address = trr!(machine.owner(), __);
             let mut data: Vec<u8> = Vec::new();
             let mut start = machine.stack.pop().unwrap();
             let start0 = start;
@@ -793,46 +795,56 @@ pub fn run_opcode<M: Memory + Default,
         Opcode::CREATE => {
             will_pop_push!(machine, 3, 1);
 
+            begin_rescuable!(machine, &mut Machine<M, S>, __);
+            let value = machine.stack.pop().unwrap();
+            let init_start = machine.stack.pop().unwrap();
+            let init_len = machine.stack.pop().unwrap();
+            on_rescue!(|machine| {
+                machine.stack.push(init_len);
+                machine.stack.push(init_start);
+                machine.stack.push(value);
+            }, __);
+            let init_end = init_start + init_len;
+            if init_end < init_start {
+                trr!(Err(ExecutionError::DataTooLarge), __);
+            }
+
+            let mut init: Vec<u8> = Vec::new();
+            let mut i = init_start;
+            while i < init_end {
+                init.push(trr!(machine.memory.read_raw(i), __));
+                i = i + M256::from(1u64);
+            }
+
+            let owner = trr!(machine.owner(), __);
+            let gas_limit = machine.available_gas() -
+                machine.available_gas() / Gas::from(64u64);
+            machine.account_nonce_inc(owner);
+            on_rescue!(|machine| {
+                machine.account_nonce_dec(owner);
+            }, __);
+            let transaction = Transaction::ContractCreation {
+                gas_price: machine.transaction().gas_price(),
+                gas_limit: gas_limit,
+                originator: machine.transaction().originator(),
+                caller: owner,
+                value: value,
+                init: init,
+            };
+
             unimplemented!()
         },
 
         Opcode::CALL => {
             will_pop_push!(machine, 7, 1);
 
-            let gas: Gas = machine.stack.pop().unwrap().into();
-            let from = machine.owner();
-            let to: Address = machine.stack.pop().unwrap().into();
-            let value = machine.stack.pop().unwrap().into();
-            let memory_in_start = machine.stack.pop().unwrap();
-            let memory_in_len = machine.stack.pop().unwrap();
-            let memory_out_start = machine.stack.pop().unwrap();
-            let memory_out_len = machine.stack.pop().unwrap();
-
-            let ret = call_code(machine, gas, from, to, value,
-                                memory_in_start, memory_in_len,
-                                memory_out_start, memory_out_len);
-
-            machine.stack.push(ret).unwrap();
+            unimplemented!()
         },
 
         Opcode::CALLCODE => {
             will_pop_push!(machine, 7, 1);
 
-            let gas: Gas = machine.stack.pop().unwrap().into();
-            machine.stack.pop().unwrap();
-            let from = machine.owner();
-            let to = machine.owner();
-            let value = machine.stack.pop().unwrap().into();
-            let memory_in_start = machine.stack.pop().unwrap();
-            let memory_in_len = machine.stack.pop().unwrap();
-            let memory_out_start = machine.stack.pop().unwrap();
-            let memory_out_len = machine.stack.pop().unwrap();
-
-            let ret = call_code(machine, gas, from, to, value,
-                                memory_in_start, memory_in_len,
-                                memory_out_start, memory_out_len);
-
-            machine.stack.push(ret).unwrap();
+            unimplemented!()
         },
 
         Opcode::RETURN => {
@@ -890,7 +902,7 @@ pub fn run_opcode<M: Memory + Default,
                 machine.stack.push(address).unwrap();
             }, __);
             let address: Address = address.into();
-            let owner = machine.owner();
+            let owner = trr!(machine.owner(), __);
 
             let balance = trr!(machine.account_balance(owner), __);
             trr!(machine.account_balance_topup(address, balance), __);

--- a/src/vm/storage.rs
+++ b/src/vm/storage.rs
@@ -1,3 +1,8 @@
+use utils::bigint::M256;
+
+use super::{ExecutionResult, ExecutionError};
+use std::collections::hash_map;
+
 pub trait Storage {
     fn read(&self, index: M256) -> ExecutionResult<M256>;
     fn write(&mut self, index: M256, value: M256) -> ExecutionResult<()>;

--- a/src/vm/storage.rs
+++ b/src/vm/storage.rs
@@ -1,0 +1,39 @@
+pub trait Storage {
+    fn read(&self, index: M256) -> ExecutionResult<M256>;
+    fn write(&mut self, index: M256, value: M256) -> ExecutionResult<()>;
+}
+
+#[derive(Debug, Clone)]
+pub struct HashMapStorage(hash_map::HashMap<M256, M256>);
+
+impl From<hash_map::HashMap<M256, M256>> for HashMapStorage {
+    fn from(val: hash_map::HashMap<M256, M256>) -> HashMapStorage {
+        HashMapStorage(val)
+    }
+}
+
+impl Into<hash_map::HashMap<M256, M256>> for HashMapStorage {
+    fn into(self) -> hash_map::HashMap<M256, M256> {
+        self.0
+    }
+}
+
+impl Default for HashMapStorage {
+    fn default() -> HashMapStorage {
+        HashMapStorage(hash_map::HashMap::new())
+    }
+}
+
+impl Storage for HashMapStorage {
+    fn read(&self, index: M256) -> ExecutionResult<M256> {
+        match self.0.get(&index) {
+            Some(&v) => Ok(v),
+            None => Ok(M256::zero())
+        }
+    }
+
+    fn write(&mut self, index: M256, val: M256) -> ExecutionResult<()> {
+        self.0.insert(index, val);
+        Ok(())
+    }
+}

--- a/src/vm/transaction.rs
+++ b/src/vm/transaction.rs
@@ -1,0 +1,91 @@
+pub enum Transaction {
+    MessageCall {
+        gas_price: Gas,
+        gas_limit: Gas,
+        to: Address,
+        originator: Address,
+        caller: Address,
+        value: M256,
+        data: Vec<u8>,
+    },
+    ContractCreation {
+        gas_price: Gas,
+        gas_limit: Gas,
+        originator: Address,
+        caller: Address,
+        value: M256,
+        init: Vec<u8>
+    }
+}
+
+impl Transaction {
+    pub fn gas_limit(&self) -> Gas {
+        match self {
+            &Transaction::MessageCall {
+                gas_limit: gas_limit,
+                ..
+            } => gas_limit,
+            &Transaction::ContractCreation {
+                gas_limit: gas_limit,
+                ..
+            } => gas_limit,
+        }
+    }
+
+    pub fn value(&self) -> M256 {
+        match self {
+            &Transaction::MessageCall {
+                value: value,
+                ..
+            } => value,
+            &Transaction::ContractCreation {
+                value: value,
+                ..
+            } => value,
+        }
+    }
+
+    pub fn caller(&self) -> Address {
+        match self {
+            &Transaction::MessageCall {
+                caller: caller,
+                ..
+            } => caller,
+            &Transaction::ContractCreation {
+                caller: caller,
+                ..
+            } => caller,
+        }
+    }
+
+    pub fn originator(&self) -> Address {
+        match self {
+            &Transaction::MessageCall {
+                originator: originator,
+                ..
+            } => originator,
+            &Transaction::ContractCreation {
+                originator: originator,
+                ..
+            } => originator,
+        }
+    }
+
+    pub fn gas_price(&self) -> Gas {
+        match self {
+            &Transaction::MessageCall {
+                gas_price: gas_price,
+                ..
+            } => gas_price,
+            &Transaction::ContractCreation {
+                gas_price: gas_price,
+                ..
+            } => gas_price,
+        }
+    }
+}
+
+pub struct TransactionMachine<M, S> {
+    transaction: Transaction,
+    machine: Option<ContextMachine<M, S>>,
+} // Also handles initialization and finalization of the transaction (gas cost move, mostly)


### PR DESCRIPTION
This refactor allows the Machine execute directly on a `Context`, rather than through a `Transaction`. At the same time, the huge chunk of state management code of account states is moved into a separate `AccountState` struct.

Next, `MessageCallMachine` and `ContractCreationMachine` will be created. Those will be wrapper around the `Machine` that execute on a transaction level.

Right now there are still work-in-progress code in `utils/rlp.rs` for RLP algorithm (steal from our wallet project), and `vm/transaction.rs` for `MessageCallMachine` and `ContractCreationMachine`, but the tests passing status is maintained. So it's good for a pull request to avoid our code divergence too much.