### PR TITLE
Problem: when transaction.to == null it's a contract creation

### DIFF
--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -57,6 +57,9 @@ fn main() {
         println!("transaction: {:?}", transaction);
         let receipt = client.get_transaction_receipt(&transaction_hash);
         println!("receipt: {:?}", receipt);
+        if transaction.to.is_empty() {
+            continue;
+        }
         let code = client.get_code(&transaction.to, &block.number);
         println!("code: {:?}", code);
 


### PR DESCRIPTION
Solution: don't process that transaction as there is no 'code' to
execute.