### PR TITLE
Block chaining regression test preparation

### DIFF
--- a/sputnikvm/src/vm/eval/mod.rs
+++ b/sputnikvm/src/vm/eval/mod.rs
@@ -168,6 +168,15 @@ impl<M: Memory + Default> Machine<M> {
         self.state.blockhash_state.commit(number, hash)
     }
 
+    pub fn finalize(&mut self) -> Result<(), RequireError> {
+        self.state.account_state.decrease_balance(self.state.context.caller,
+                                                  self.state.context.value);
+        self.state.account_state.increase_balance(self.state.context.address,
+                                                  self.state.context.value);
+
+        Ok(())
+    }
+
     #[allow(unused_variables)]
     /// Apply a sub runtime into the current runtime. This sub runtime
     /// should have been created by the current runtime's `derive`

--- a/sputnikvm/src/vm/mod.rs
+++ b/sputnikvm/src/vm/mod.rs
@@ -103,6 +103,13 @@ impl<M: Memory + Default> ContextVM<M> {
         }
     }
 
+    pub fn with_previous(context: Context, block: BlockHeader, patch: &'static Patch,
+                         vm: &ContextVM<M>) -> Self {
+        Self::with_states(context, block, patch,
+                          vm.machines[0].state().account_state.clone(),
+                          vm.machines[0].state().blockhash_state.clone())
+    }
+
     /// Returns the call create history. Only used in testing.
     pub fn history(&self) -> &[Context] {
         self.history.as_slice()

--- a/sputnikvm/src/vm/transaction.rs
+++ b/sputnikvm/src/vm/transaction.rs
@@ -137,6 +137,28 @@ impl<M: Memory + Default> TransactionVM<M> {
             blockhash_state: BlockhashState::default(),
         })
     }
+
+    pub fn with_previous(transaction: Transaction, block: BlockHeader, patch: &'static Patch,
+                         vm: &TransactionVM<M>) -> Self {
+        TransactionVM(TransactionVMState::Constructing {
+            transaction: transaction,
+            block: block,
+            patch: patch,
+
+            account_state: match vm.0 {
+                TransactionVMState::Constructing { ref account_state, .. } =>
+                    account_state.clone(),
+                TransactionVMState::Running { ref vm, .. } =>
+                    vm.machines[0].state().account_state.clone(),
+            },
+            blockhash_state: match vm.0 {
+                TransactionVMState::Constructing { ref blockhash_state, .. } =>
+                    blockhash_state.clone(),
+                TransactionVMState::Running { ref vm, .. } =>
+                    vm.machines[0].state().blockhash_state.clone(),
+            },
+        })
+    }
 }
 
 impl<M: Memory + Default> VM for TransactionVM<M> {

--- a/sputnikvm/src/vm/transaction.rs
+++ b/sputnikvm/src/vm/transaction.rs
@@ -113,6 +113,7 @@ enum TransactionVMState<M> {
     Running {
         vm: ContextVM<M>,
         intrinsic_gas: Gas,
+        finalized: bool,
     },
     Constructing {
         transaction: Transaction,
@@ -178,7 +179,13 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
 
     fn status(&self) -> VMStatus {
         match self.0 {
-            TransactionVMState::Running { ref vm, .. } => vm.status(),
+            TransactionVMState::Running { ref vm, finalized, .. } => {
+                if !finalized {
+                    VMStatus::Running
+                } else {
+                    vm.status()
+                }
+            },
             TransactionVMState::Constructing { .. } => VMStatus::Running,
         }
     }
@@ -192,7 +199,22 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
         let mut cblockhash_state: Option<BlockhashState> = None;
 
         match self.0 {
-            TransactionVMState::Running { ref mut vm, .. } => return vm.step(),
+            TransactionVMState::Running { ref mut vm, ref mut finalized, .. } => {
+                match vm.status() {
+                    VMStatus::Running => {
+                        return vm.step();
+                    },
+                    _ => {
+                        if !*finalized {
+                            vm.machines[0].finalize()?;
+                            *finalized = true;
+                            return Ok(());
+                        } else {
+                            return vm.step();
+                        }
+                    },
+                }
+            }
             TransactionVMState::Constructing {
                 ref transaction, ref block, ref patch,
                 ref account_state, ref blockhash_state } => {
@@ -210,6 +232,7 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
             vm: ContextVM::with_states(ccontext.unwrap(), cblock.unwrap(), cpatch.unwrap(),
                                        caccount_state.unwrap(), cblockhash_state.unwrap()),
             intrinsic_gas: cgas.unwrap(),
+            finalized: false,
         };
 
         Ok(())
@@ -238,7 +261,7 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
 
     fn used_gas(&self) -> Gas {
         match self.0 {
-            TransactionVMState::Running { ref vm, intrinsic_gas } => vm.used_gas() + intrinsic_gas,
+            TransactionVMState::Running { ref vm, intrinsic_gas, .. } => vm.used_gas() + intrinsic_gas,
             TransactionVMState::Constructing { .. } => Gas::zero(),
         }
     }


### PR DESCRIPTION
Add TransactionVM finalization support and allow constructing new VMs from previous VM state. Part of #122.