### PR TITLE
Problem: block 46402, gas cost mismatch

### DIFF
--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -66,7 +66,7 @@ fn handle_fire(client: &mut GethRPCClient, vm: &mut SeqTransactionVM, last_block
     loop {
         match vm.fire() {
             Ok(()) => {
-                println!("VM exited successfully, checking results ...");
+                println!("VM exited with {:?}.", vm.status());
                 break;
             },
             Err(RequireError::Account(address)) => {

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -132,7 +132,7 @@ fn test_block(client: &mut GethRPCClient, number: usize) {
 
         handle_fire(client, &mut vm, &format!("0x{:x}", last_number));
 
-        assert!(Gas::from_str(&receipt.gasUsed).unwrap() == vm.used_gas());
+        assert!(Gas::from_str(&receipt.gasUsed).unwrap() == vm.real_used_gas());
         assert!(receipt.logs.len() == vm.logs().len());
         for i in 0..receipt.logs.len() {
             assert!(from_rpc_log(&receipt.logs[i]) == vm.logs()[i]);

--- a/sputnikvm/src/vm/eval/mod.rs
+++ b/sputnikvm/src/vm/eval/mod.rs
@@ -371,4 +371,14 @@ impl<M: Memory + Default> Machine<M> {
     pub fn status(&self) -> MachineStatus {
         self.status.clone()
     }
+
+    /// If the machine is exited with EmptyGas, return gas_limit,
+    /// otherwise return the sum of memory gas and used gas.
+    pub fn real_used_gas(&self) -> Gas {
+        match self.status() {
+            MachineStatus::ExitedErr(MachineError::EmptyGas) =>
+                self.state.context.gas_limit,
+            _ => self.state.memory_gas() + self.state.used_gas,
+        }
+    }
 }

--- a/sputnikvm/src/vm/mod.rs
+++ b/sputnikvm/src/vm/mod.rs
@@ -66,7 +66,7 @@ pub trait VM {
     fn accounts(&self) -> hash_map::Values<Address, Account>;
     fn out(&self) -> &[u8];
     fn available_gas(&self) -> Gas;
-    fn used_gas(&self) -> Gas;
+    fn real_used_gas(&self) -> Gas;
     fn refunded_gas(&self) -> Gas;
     fn logs(&self) -> &[Log];
 }
@@ -199,9 +199,10 @@ impl<M: Memory + Default> VM for ContextVM<M> {
         self.machines[0].state().available_gas()
     }
 
-    /// Returns the used gas of this VM.
-    fn used_gas(&self) -> Gas {
-        self.machines[0].state().memory_gas() + self.machines[0].state().used_gas
+    /// If the VM is exited with EmptyGas, return gas_limit,
+    /// otherwise return the sum of memory gas and used gas.
+    fn real_used_gas(&self) -> Gas {
+        self.machines[0].real_used_gas()
     }
 
     /// Returns the refunded gas of this VM.

--- a/sputnikvm/src/vm/transaction.rs
+++ b/sputnikvm/src/vm/transaction.rs
@@ -259,9 +259,9 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
         }
     }
 
-    fn used_gas(&self) -> Gas {
+    fn real_used_gas(&self) -> Gas {
         match self.0 {
-            TransactionVMState::Running { ref vm, intrinsic_gas, .. } => vm.used_gas() + intrinsic_gas,
+            TransactionVMState::Running { ref vm, intrinsic_gas, .. } => vm.real_used_gas() + intrinsic_gas,
             TransactionVMState::Constructing { .. } => Gas::zero(),
         }
     }


### PR DESCRIPTION
Solution: used_gas -> real_used_gas

See
https://jenkins.that.world/view/SputnikVM%20Blockchain%20Regression/job/SputnikVM%20Blockchain%20Regression%20Frontier/2/console
for the error.

When the VM is exited with empty gas, it should use the context's gas
limit, rather than the gas that has been use in prior to the last
instruction.