### PR TITLE
Problem: coverall messages are annoying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,7 @@ script:
     export PATH="$PATH":~/.cargo/bin &&
     export RUST_BACKTRACE=1 &&
     cargo build --all --verbose &&
-    cargo test --all --verbose &&
-    cargo install cargo-kcov --force &&
-    cargo kcov --all -- --verify --exclude-pattern=/.cargo,/usr/lib --coveralls-id=$TRAVIS_JOB_ID
+    cargo test --all --verbose
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
See #197 for an example on how annoying this can be. This just
temporarily remove coverall tests (which isn't the matrix we're
monitoring right now).