### PR TITLE
Problem: shell.nix will not work if `pkgs` param is provided

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (
+let pkgs = (
   let
     nixpkgs = import <nixpkgs>;
     pkgs_ = (nixpkgs {});
@@ -22,10 +22,9 @@
         });
       })
     ];
-  }))
-}:
+  }));
 
-with pkgs;
+in with pkgs;
 
 stdenv.mkDerivation {
   name = "sputnikvm-env";


### PR DESCRIPTION
If it is provided, the overlay will not be in place, and further calls
below to fetch rustc and cargo will fail.