### PR TITLE
Additional fixes for Frontier block range regression

### DIFF
--- a/bigint/src/u512.rs
+++ b/bigint/src/u512.rs
@@ -5,7 +5,7 @@ use std::ops::{Add, Sub, Mul, Div, Shr, Shl, BitAnd, Rem};
 use std::cmp::Ordering;
 use std::fmt;
 
-use super::U256;
+use super::{U256, Sign};
 use super::algorithms::{add2, mac3, from_signed, sub2_sign};
 
 #[repr(C)]
@@ -153,6 +153,7 @@ impl Sub for U512 {
         let U512(ref b) = other;
 
         let sign = sub2_sign(a, b);
+        assert!(sign != Sign::Minus);
         from_signed(sign, a);
         U512(*a)
     }

--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -94,11 +94,7 @@ impl JSONBlock {
                 self.set_account_nonce(address, nonce);
             },
             Account::Create {
-                address: address,
-                balance: balance,
-                storage: storage,
-                code: code,
-                nonce: nonce,
+                address, balance, storage, code, nonce, ..
             } => {
                 self.set_balance(address, balance);
                 self.set_account_code(address, code.as_slice());

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -77,6 +77,7 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
         config.insert(Address::from_str("0x4fea5cb278edfabcc24f7c1425951a0d2faa609b").unwrap(), 370489);
         config.insert(Address::from_str("0x000000000000000000000000000007329b54129c").unwrap(), 254277);
         config.insert(Address::from_str("0x0000000000000000000000000000000000000194").unwrap(), 257654);
+        config.insert(Address::from_str("0xf5ed057f297c6389d80245c8631b040f05804578").unwrap(), 637752);
 
         config
     };

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -72,6 +72,8 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
         config.insert(Address::from_str("0x0000000000000000000000000000000000000003").unwrap(), 0);
         config.insert(Address::from_str("0x0000000000000000000000000000000000000004").unwrap(), 0);
 
+        config.insert(Address::from_str("0xbfe465e7eb5a2928b5bf22bef93ad06089dc6179").unwrap(), 229894);
+
         config
     };
 

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -75,6 +75,7 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
         config.insert(Address::from_str("0xbfe465e7eb5a2928b5bf22bef93ad06089dc6179").unwrap(), 229894);
         config.insert(Address::from_str("0xc7585b4ea1829ef37f2fcc6ceaa6063700000000").unwrap(), 188235);
         config.insert(Address::from_str("0x4fea5cb278edfabcc24f7c1425951a0d2faa609b").unwrap(), 370489);
+        config.insert(Address::from_str("0x000000000000000000000000000007329b54129c").unwrap(), 254277);
 
         config
     };

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -73,6 +73,7 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
         config.insert(Address::from_str("0x0000000000000000000000000000000000000004").unwrap(), 0);
 
         config.insert(Address::from_str("0xbfe465e7eb5a2928b5bf22bef93ad06089dc6179").unwrap(), 229894);
+        config.insert(Address::from_str("0xc7585b4ea1829ef37f2fcc6ceaa6063700000000").unwrap(), 188235);
 
         config
     };

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -77,12 +77,16 @@ fn handle_fire(client: &mut GethRPCClient, vm: &mut SeqTransactionVM, last_block
                                                                  &last_block_number)).unwrap();
                 let code = read_hex(&client.get_code(&format!("0x{:x}", address),
                                                      &last_block_number)).unwrap();
-                vm.commit_account(AccountCommitment::Full {
-                    nonce: nonce,
-                    address: address,
-                    balance: balance,
-                    code: code,
-                }).unwrap();
+                if nonce == M256::zero() && balance == U256::zero() && code.len() == 0 {
+                    vm.commit_account(AccountCommitment::Nonexist(address)).unwrap();
+                } else {
+                    vm.commit_account(AccountCommitment::Full {
+                        nonce: nonce,
+                        address: address,
+                        balance: balance,
+                        code: code,
+                    }).unwrap();
+                }
             },
             Err(RequireError::AccountStorage(address, index)) => {
                 println!("Feeding VM account storage at 0x{:x} with index 0x{:x} ...", address, index);

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -74,6 +74,7 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
 
         config.insert(Address::from_str("0xbfe465e7eb5a2928b5bf22bef93ad06089dc6179").unwrap(), 229894);
         config.insert(Address::from_str("0xc7585b4ea1829ef37f2fcc6ceaa6063700000000").unwrap(), 188235);
+        config.insert(Address::from_str("0x4fea5cb278edfabcc24f7c1425951a0d2faa609b").unwrap(), 370489);
 
         config
     };

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -76,6 +76,7 @@ fn irregular_addresses(number: usize) -> HashSet<Address> {
         config.insert(Address::from_str("0xc7585b4ea1829ef37f2fcc6ceaa6063700000000").unwrap(), 188235);
         config.insert(Address::from_str("0x4fea5cb278edfabcc24f7c1425951a0d2faa609b").unwrap(), 370489);
         config.insert(Address::from_str("0x000000000000000000000000000007329b54129c").unwrap(), 254277);
+        config.insert(Address::from_str("0x0000000000000000000000000000000000000194").unwrap(), 257654);
 
         config
     };

--- a/sputnikvm/src/vm/commit/account.rs
+++ b/sputnikvm/src/vm/commit/account.rs
@@ -152,6 +152,17 @@ impl AccountState {
         self.storage(address)?.read(index).and_then(|_| Ok(()))
     }
 
+    pub fn mark_exists(&mut self, address: Address) -> Result<(), RequireError> {
+        match self.accounts.get_mut(&address) {
+            Some(&mut Account::Full { .. }) => Ok(()),
+            Some(&mut Account::Create { ref mut exists, .. }) => {
+                *exists = true;
+                Ok(())
+            },
+            _ => Err(RequireError::Account(address)),
+        }
+    }
+
     /// Commit an account commitment into this account state.
     pub fn commit(&mut self, commitment: AccountCommitment) -> Result<(), CommitError> {
         match commitment {

--- a/sputnikvm/src/vm/eval/check.rs
+++ b/sputnikvm/src/vm/eval/check.rs
@@ -11,7 +11,7 @@ use super::utils::{check_range, check_memory_write_range};
 
 pub fn extra_check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), EvalError> {
     match instruction {
-        Instruction::CALL => {
+        Instruction::CALL | Instruction::CALLCODE => {
             if after_gas - stipend_gas < state.stack.peek(0).unwrap().into() {
                 Err(EvalError::Machine(MachineError::EmptyGas))
             } else {

--- a/sputnikvm/src/vm/eval/check.rs
+++ b/sputnikvm/src/vm/eval/check.rs
@@ -7,7 +7,7 @@ use vm::{Memory, Instruction};
 use vm::errors::{MachineError, EvalError};
 
 use vm::eval::{State, ControlCheck};
-use super::utils::{check_range, check_memory_write_range};
+use super::utils::check_range;
 
 #[allow(unused_variables)]
 pub fn extra_check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), EvalError> {
@@ -72,15 +72,15 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALLDATASIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CALLDATACOPY => {
             state.stack.check_pop_push(3, 0)?;
-            check_memory_write_range(&state.memory,
-                                     state.stack.peek(0).unwrap(), state.stack.peek(2).unwrap())?;
+            state.memory.check_write_range(
+                state.stack.peek(0).unwrap(), state.stack.peek(2).unwrap())?;
             Ok(None)
         },
         Instruction::CODESIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CODECOPY => {
             state.stack.check_pop_push(3, 0)?;
-            check_memory_write_range(&state.memory,
-                               state.stack.peek(0).unwrap(), state.stack.peek(2).unwrap())?;
+            state.memory.check_write_range(
+                state.stack.peek(0).unwrap(), state.stack.peek(2).unwrap())?;
             Ok(None)
         },
         Instruction::GASPRICE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
@@ -92,8 +92,8 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::EXTCODECOPY => {
             state.stack.check_pop_push(4, 0)?;
             state.account_state.require_code(state.stack.peek(0).unwrap().into())?;
-            check_memory_write_range(&state.memory,
-                                     state.stack.peek(1).unwrap(), state.stack.peek(3).unwrap())?;
+            state.memory.check_write_range(
+                state.stack.peek(1).unwrap(), state.stack.peek(3).unwrap())?;
             Ok(None)
         },
 
@@ -172,8 +172,8 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALL => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap(), state.stack.peek(4).unwrap())?;
-            check_memory_write_range(&state.memory,
-                                     state.stack.peek(5).unwrap(), state.stack.peek(6).unwrap())?;
+            state.memory.check_write_range(
+                state.stack.peek(5).unwrap(), state.stack.peek(6).unwrap())?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
@@ -181,8 +181,8 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALLCODE => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap(), state.stack.peek(4).unwrap())?;
-            check_memory_write_range(&state.memory,
-                                     state.stack.peek(5).unwrap(), state.stack.peek(6).unwrap())?;
+            state.memory.check_write_range(
+                state.stack.peek(5).unwrap(), state.stack.peek(6).unwrap())?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)

--- a/sputnikvm/src/vm/eval/check.rs
+++ b/sputnikvm/src/vm/eval/check.rs
@@ -196,6 +196,7 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::SUICIDE => {
             state.stack.check_pop_push(1, 0)?;
             state.account_state.require(state.context.address)?;
+            state.account_state.require(state.stack.peek(0).unwrap().into())?;
             Ok(None)
         },
     }

--- a/sputnikvm/src/vm/eval/check.rs
+++ b/sputnikvm/src/vm/eval/check.rs
@@ -13,7 +13,7 @@ use super::utils::{check_range, check_memory_write_range};
 pub fn extra_check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), EvalError> {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE => {
-            if after_gas < state.stack.peek(0).unwrap().into() {
+            if after_gas < stipend_gas || after_gas - stipend_gas < state.stack.peek(0).unwrap().into() {
                 Err(EvalError::Machine(MachineError::EmptyGas))
             } else {
                 Ok(())

--- a/sputnikvm/src/vm/eval/check.rs
+++ b/sputnikvm/src/vm/eval/check.rs
@@ -9,10 +9,11 @@ use vm::errors::{MachineError, EvalError};
 use vm::eval::{State, ControlCheck};
 use super::utils::{check_range, check_memory_write_range};
 
+#[allow(unused_variables)]
 pub fn extra_check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), EvalError> {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE => {
-            if after_gas - stipend_gas < state.stack.peek(0).unwrap().into() {
+            if after_gas < state.stack.peek(0).unwrap().into() {
                 Err(EvalError::Machine(MachineError::EmptyGas))
             } else {
                 Ok(())

--- a/sputnikvm/src/vm/eval/cost.rs
+++ b/sputnikvm/src/vm/eval/cost.rs
@@ -7,7 +7,6 @@ use utils::bigint::{M256, U256};
 use std::cmp::max;
 use vm::{Memory, Instruction};
 use super::State;
-use super::precompiled::is_precompiled;
 
 const G_ZERO: usize = 0;
 const G_BASE: usize = 2;
@@ -66,7 +65,7 @@ fn xfer_cost<M: Memory + Default>(machine: &State<M>) -> Gas {
 
 fn new_cost<M: Memory + Default>(machine: &State<M>, is_callcode: bool) -> Gas {
     let address: Address = machine.stack.peek(1).unwrap().into();
-    if !machine.account_state.exists(address).unwrap() && !is_precompiled(address) && !is_callcode {
+    if !machine.account_state.exists(address).unwrap() && !is_callcode {
         Gas::from(G_NEWACCOUNT)
     } else {
         Gas::zero()
@@ -247,7 +246,7 @@ pub fn gas_cost<M: Memory + Default>(instruction: Instruction, state: &State<M>)
 /// Raise gas stipend for CALL and CALLCODE instruction.
 pub fn gas_stipend<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Gas {
     match instruction {
-        Instruction::CALL | Instruction::CALLCODE => {
+        Instruction::CALL => {
             let value = state.stack.peek(2).unwrap();
 
             if value != M256::zero() {

--- a/sputnikvm/src/vm/eval/cost.rs
+++ b/sputnikvm/src/vm/eval/cost.rs
@@ -66,8 +66,8 @@ fn xfer_cost<M: Memory + Default>(machine: &State<M>) -> Gas {
 
 fn new_cost<M: Memory + Default>(machine: &State<M>, is_callcode: bool) -> Gas {
     let address: Address = machine.stack.peek(1).unwrap().into();
-    if machine.account_state.balance(address).unwrap() == U256::zero() && machine.account_state.nonce(address).unwrap() == M256::zero() && machine.account_state.code(address).unwrap().len() == 0 && !is_precompiled(address) && !is_callcode {
-        G_NEWACCOUNT.into()
+    if !machine.account_state.exists(address).unwrap() && !is_precompiled(address) && !is_callcode {
+        Gas::from(G_NEWACCOUNT)
     } else {
         Gas::zero()
     }
@@ -75,7 +75,7 @@ fn new_cost<M: Memory + Default>(machine: &State<M>, is_callcode: bool) -> Gas {
 
 fn suicide_cost<M: Memory + Default>(machine: &State<M>) -> Gas {
     let address: Address = machine.stack.peek(0).unwrap().into();
-    Gas::from(machine.patch.gas_suicide) + if address == Address::default() {
+    Gas::from(machine.patch.gas_suicide) + if !machine.account_state.exists(address).unwrap() {
         Gas::from(G_NEWACCOUNT)
     } else {
         Gas::zero()

--- a/sputnikvm/src/vm/eval/cost.rs
+++ b/sputnikvm/src/vm/eval/cost.rs
@@ -246,7 +246,7 @@ pub fn gas_cost<M: Memory + Default>(instruction: Instruction, state: &State<M>)
 /// Raise gas stipend for CALL and CALLCODE instruction.
 pub fn gas_stipend<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Gas {
     match instruction {
-        Instruction::CALL => {
+        Instruction::CALL | Instruction::CALLCODE => {
             let value = state.stack.peek(2).unwrap();
 
             if value != M256::zero() {

--- a/sputnikvm/src/vm/eval/lifecycle.rs
+++ b/sputnikvm/src/vm/eval/lifecycle.rs
@@ -69,6 +69,7 @@ impl<M: Memory + Default> Machine<M> {
             MachineStatus::ExitedErr(_) => {
                 // If exited with error, reset all changes.
                 self.state.account_state = fresh_account_state.clone();
+                self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
                 self.state.logs = Vec::new();
                 self.state.removed = Vec::new();
             },

--- a/sputnikvm/src/vm/eval/lifecycle.rs
+++ b/sputnikvm/src/vm/eval/lifecycle.rs
@@ -21,23 +21,27 @@ use super::cost::code_deposit_gas;
 
 impl<M: Memory + Default> Machine<M> {
     pub fn initialize_call(&mut self, preclaimed_value: U256) {
+        self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
         self.state.account_state.increase_balance(self.state.context.address, self.state.context.value);
     }
 
     pub fn invoke_call(&mut self) {
+        self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
         self.state.account_state.increase_balance(self.state.context.address, self.state.context.value);
     }
 
     pub fn initialize_create(&mut self, preclaimed_value: U256) {
+        self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
         self.state.account_state.create(self.state.context.address, self.state.context.value);
     }
 
     pub fn invoke_create(&mut self) {
+        self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
         self.state.account_state.create(self.state.context.address, self.state.context.value);
     }

--- a/sputnikvm/src/vm/eval/lifecycle.rs
+++ b/sputnikvm/src/vm/eval/lifecycle.rs
@@ -4,7 +4,7 @@ use vm::errors::{RequireError, MachineError};
 use vm::commit::AccountState;
 use vm::Memory;
 use super::{Machine, MachineStatus};
-use super::utils::copy_into_memory;
+use super::utils::copy_into_memory_apply;
 use super::cost::code_deposit_gas;
 
 /// # Lifecycle of a Machine
@@ -156,8 +156,8 @@ impl<M: Memory + Default> Machine<M> {
                 self.state.removed = sub.state.removed;
                 self.state.used_gas = self.state.used_gas + sub_total_used_gas;
                 self.state.refunded_gas = self.state.refunded_gas + sub.state.refunded_gas;
-                copy_into_memory(&mut self.state.memory, sub.state.out.as_slice(),
-                                 out_start, M256::zero(), out_len);
+                copy_into_memory_apply(&mut self.state.memory, sub.state.out.as_slice(),
+                                       out_start, out_len);
             },
             MachineStatus::ExitedErr(_) => {
                 self.state.used_gas = self.state.used_gas + sub.state.context.gas_limit;

--- a/sputnikvm/src/vm/eval/lifecycle.rs
+++ b/sputnikvm/src/vm/eval/lifecycle.rs
@@ -33,17 +33,25 @@ impl<M: Memory + Default> Machine<M> {
         self.state.account_state.increase_balance(self.state.context.address, self.state.context.value);
     }
 
-    pub fn initialize_create(&mut self, preclaimed_value: U256) {
+    pub fn initialize_create(&mut self, preclaimed_value: U256) -> Result<(), RequireError> {
+        self.state.account_state.require(self.state.context.address)?;
+
         self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
-        self.state.account_state.create(self.state.context.address, self.state.context.value);
+        self.state.account_state.create(self.state.context.address, self.state.context.value).unwrap();
+
+        Ok(())
     }
 
-    pub fn invoke_create(&mut self) {
+    pub fn invoke_create(&mut self) -> Result<(), RequireError> {
+        self.state.account_state.require(self.state.context.address)?;
+
         self.state.account_state.premark_exists(self.state.context.address);
         self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
-        self.state.account_state.create(self.state.context.address, self.state.context.value);
+        self.state.account_state.create(self.state.context.address, self.state.context.value).unwrap();
+
+        Ok(())
     }
 
     pub fn code_deposit(&mut self) -> Result<(), RequireError> {
@@ -68,6 +76,8 @@ impl<M: Memory + Default> Machine<M> {
     }
 
     pub fn finalize(&mut self, real_used_gas: Gas, preclaimed_value: U256, fresh_account_state: &AccountState) -> Result<(), RequireError> {
+        self.state.account_state.require(self.state.context.address)?;
+
         match self.status() {
             MachineStatus::ExitedOk => (),
             MachineStatus::ExitedErr(_) => {

--- a/sputnikvm/src/vm/eval/run/system.rs
+++ b/sputnikvm/src/vm/eval/run/system.rs
@@ -63,6 +63,8 @@ pub fn create<M: Memory + Default>(state: &mut State<M>, after_gas: Gas) -> Opti
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
 
+    state.account_state.mark_exists(context.address).unwrap();
+
     push!(state, context.address.into());
     Some(context)
 }
@@ -86,12 +88,16 @@ pub fn call<M: Memory + Default>(state: &mut State<M>, stipend_gas: Gas, after_g
         value: value,
         data: input,
     };
+
     let mut context = transaction.into_context(
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
     if as_self {
         context.address = state.context.address;
     }
+
+    state.account_state.mark_exists(context.address).unwrap();
+
     push!(state, M256::from(1u64));
     Some((context, (out_start, out_len)))
 }

--- a/sputnikvm/src/vm/eval/run/system.rs
+++ b/sputnikvm/src/vm/eval/run/system.rs
@@ -63,8 +63,6 @@ pub fn create<M: Memory + Default>(state: &mut State<M>, after_gas: Gas) -> Opti
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
 
-    state.account_state.mark_exists(context.address).unwrap();
-
     push!(state, context.address.into());
     Some(context)
 }

--- a/sputnikvm/src/vm/eval/run/system.rs
+++ b/sputnikvm/src/vm/eval/run/system.rs
@@ -94,8 +94,6 @@ pub fn call<M: Memory + Default>(state: &mut State<M>, stipend_gas: Gas, after_g
         context.address = state.context.address;
     }
 
-    state.account_state.mark_exists(context.address).unwrap();
-
     push!(state, M256::from(1u64));
     Some((context, (out_start, out_len)))
 }

--- a/sputnikvm/src/vm/eval/run/system.rs
+++ b/sputnikvm/src/vm/eval/run/system.rs
@@ -13,9 +13,9 @@ use vm::eval::utils::copy_from_memory;
 pub fn suicide<M: Memory + Default>(state: &mut State<M>) {
     pop!(state, address: Address);
     let balance = state.account_state.balance(state.context.address).unwrap();
-    state.account_state.increase_balance(address, balance);
     state.account_state.remove(state.context.address).unwrap();
-    state.removed.push(address);
+    state.removed.push(state.context.address);
+    state.account_state.increase_balance(address, balance);
 }
 
 pub fn log<M: Memory + Default>(state: &mut State<M>, topic_len: usize) {

--- a/sputnikvm/src/vm/eval/utils.rs
+++ b/sputnikvm/src/vm/eval/utils.rs
@@ -4,6 +4,7 @@ use utils::bigint::M256;
 use utils::gas::Gas;
 use vm::Memory;
 use vm::errors::MachineError;
+use std::cmp::min;
 
 pub fn l64(gas: Gas) -> Gas {
     gas - gas / Gas::from(64u64)
@@ -51,5 +52,17 @@ pub fn copy_into_memory<M: Memory>(memory: &mut M, values: &[u8], start: M256, v
             memory.write_raw(i, 0u8).unwrap();
         }
         i = i + M256::from(1u64);
+    }
+}
+
+pub fn copy_into_memory_apply<M: Memory>(memory: &mut M, values: &[u8], start: M256, len: M256) {
+    let value_len = M256::from(values.len());
+    let actual_len = min(len, value_len);
+    let mut i = start;
+    let mut j = 0;
+    while i < start + actual_len {
+        memory.write_raw(i, values[j]).unwrap();
+        i = i + M256::from(1u64);
+        j = j + 1;
     }
 }

--- a/sputnikvm/src/vm/eval/utils.rs
+++ b/sputnikvm/src/vm/eval/utils.rs
@@ -18,16 +18,6 @@ pub fn check_range(start: M256, len: M256) -> Result<(), MachineError> {
     }
 }
 
-pub fn check_memory_write_range<M: Memory>(memory: &M, start: M256, len: M256) -> Result<(), MachineError> {
-    check_range(start, len)?;
-    let mut i = start;
-    while i < start + len {
-        memory.check_write(i)?;
-        i = i + M256::from(1u64);
-    }
-    Ok(())
-}
-
 pub fn copy_from_memory<M: Memory>(memory: &M, start: M256, len: M256) -> Vec<u8> {
     let mut result: Vec<u8> = Vec::new();
     let mut i = start;

--- a/sputnikvm/src/vm/memory.rs
+++ b/sputnikvm/src/vm/memory.rs
@@ -11,6 +11,7 @@ pub trait Memory {
     /// this function returns None, then both `write` and `write_raw`
     /// on this index should succeed.
     fn check_write(&self, index: M256) -> Result<(), MemoryError>;
+    fn check_write_range(&self, start: M256, len: M256) -> Result<(), MemoryError>;
 
     /// Write value into the index.
     fn write(&mut self, index: M256, value: M256) -> Result<(), MemoryError>;
@@ -43,6 +44,18 @@ impl Memory for SeqMemory {
             Err(MemoryError::IndexNotSupported)
         } else {
             Ok(())
+        }
+    }
+
+    fn check_write_range(&self, start: M256, len: M256) -> Result<(), MemoryError> {
+        if len == M256::zero() {
+            return Ok(());
+        }
+
+        if start + len < start {
+            Err(MemoryError::IndexNotSupported)
+        } else {
+            self.check_write(start + len - M256::from(1u64))
         }
     }
 

--- a/sputnikvm/src/vm/mod.rs
+++ b/sputnikvm/src/vm/mod.rs
@@ -170,9 +170,9 @@ impl<M: Memory + Default> VM for ContextVM<M> {
                 Ok(())
             },
             MachineStatus::InvokeCreate(context) => {
-                self.history.push(context.clone());
-                let mut sub = self.machines.last().unwrap().derive(context);
-                sub.invoke_create();
+                let mut sub = self.machines.last().unwrap().derive(context.clone());
+                sub.invoke_create()?;
+                self.history.push(context);
                 self.machines.push(sub);
                 Ok(())
             },


### PR DESCRIPTION
This finishes testing for block 1..700000. A new concept, called "irregular accounts", are added. Those are accounts that are considered existing, but with zero balance, zero nonce and no code. Right now there's no RPC method to query whether an account exists or not. So this issue is being addressed by #206.