### PR TITLE
Add prefix `sputnikvm-` for crate rlp/bigint and add crate descs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "gethrpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -179,11 +179,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "jsontests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm 0.1.0",
+ "sputnikvm 0.2.0",
 ]
 
 [[package]]
@@ -335,12 +335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regtests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gethrpc 0.1.0",
+ "gethrpc 0.2.0",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm 0.1.0",
+ "sputnikvm 0.2.0",
  "sputnikvm-bigint 0.2.0",
 ]
 
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "sputnikvm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,15 +1,11 @@
 [root]
-name = "sputnikvm"
-version = "0.1.0"
+name = "sputnikvm-rlp"
+version = "0.2.0"
 dependencies = [
- "bigint 0.1.0",
- "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd160 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rlp 0.2.0",
- "secp256k1 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "elastic-array 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,13 +38,6 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "bigint"
-version = "0.1.0"
-dependencies = [
- "rlp 0.2.0",
 ]
 
 [[package]]
@@ -348,11 +337,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "regtests"
 version = "0.1.0"
 dependencies = [
- "bigint 0.1.0",
  "clap 2.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gethrpc 0.1.0",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "sputnikvm 0.1.0",
+ "sputnikvm-bigint 0.2.0",
 ]
 
 [[package]]
@@ -364,16 +353,6 @@ dependencies = [
  "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rlp"
-version = "0.2.0"
-dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic-array 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -469,6 +448,27 @@ dependencies = [
  "digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sputnikvm"
+version = "0.1.0"
+dependencies = [
+ "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd160 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sputnikvm-bigint 0.2.0",
+ "sputnikvm-rlp 0.2.0",
+ "tiny-keccak 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sputnikvm-bigint"
+version = "0.2.0"
+dependencies = [
+ "sputnikvm-rlp 0.2.0",
 ]
 
 [[package]]

--- a/bigint/Cargo.toml
+++ b/bigint/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "bigint"
-version = "0.1.0"
+name = "sputnikvm-bigint"
+version = "0.2.0"
+license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
+description = "Big integer (256-bit and 512-bit) implementation for SputnikVM."
+repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-rlp = { path = '../rlp' }
+sputnikvm-rlp = { path = '../rlp' }

--- a/bigint/src/lib.rs
+++ b/bigint/src/lib.rs
@@ -1,5 +1,5 @@
 mod algorithms;
-extern crate rlp;
+extern crate sputnikvm_rlp as rlp;
 
 mod m256;
 mod mi256;

--- a/gethrpc/Cargo.toml
+++ b/gethrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gethrpc"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "gethrpc - provides functionality for interacting with geth's blockchain."

--- a/gethrpc/Cargo.toml
+++ b/gethrpc/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "gethrpc - provides functionality for interacting with geth's blockchain."
-
-[lib]
-name = "gethrpc"
+repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
 clap = "2.22"

--- a/jsontests/Cargo.toml
+++ b/jsontests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsontests"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 

--- a/regtests/Cargo.toml
+++ b/regtests/Cargo.toml
@@ -10,7 +10,7 @@ name = "regtests"
 
 [dependencies]
 sputnikvm = { path = '../sputnikvm' }
-bigint = { path = '../bigint' }
+sputnikvm-bigint = { path = '../bigint' }
 gethrpc = { path = '../gethrpc' }
 clap = "2.22"
 serde_json = "0.9"

--- a/regtests/Cargo.toml
+++ b/regtests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regtests"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "regtests - performs a regression test of the entire ethereum classic blockchain."

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate clap;
 extern crate sputnikvm;
-extern crate bigint;
+extern crate sputnikvm_bigint as bigint;
 extern crate serde_json;
 extern crate gethrpc;
 

--- a/rlp/Cargo.toml
+++ b/rlp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 description = "Recursive-length prefix encoding, decoding, and compression"
-repository = "https://github.com/paritytech/parity"
+repository = "https://github.com/ethereumproject/sputnikvm"
 license = "MIT/Apache-2.0"
-name = "rlp"
+name = "sputnikvm-rlp"
 version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 

--- a/rlp/src/lib.rs
+++ b/rlp/src/lib.rs
@@ -72,7 +72,7 @@ pub const EMPTY_LIST_RLP: [u8; 1] = [0xC0; 1];
 /// Shortcut function to decode trusted rlp
 ///
 /// ```rust
-/// extern crate rlp;
+/// extern crate sputnikvm_rlp as rlp;
 ///
 /// fn main () {
 /// 	let data = vec![0x83, b'c', b'a', b't'];
@@ -93,7 +93,7 @@ pub fn decode_list<T>(bytes: &[u8]) -> Vec<T> where T: Decodable {
 /// Shortcut function to encode structure into rlp.
 ///
 /// ```rust
-/// extern crate rlp;
+/// extern crate sputnikvm_rlp as rlp;
 ///
 /// fn main () {
 /// 	let animal = "cat";

--- a/rlp/src/rlpin.rs
+++ b/rlp/src/rlpin.rs
@@ -41,7 +41,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// The raw data of the RLP as slice.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -73,7 +73,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Returns number of RLP items.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -91,7 +91,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Returns the number of bytes in the data, or zero if it isn't data.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -112,7 +112,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// slices is faster.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -129,7 +129,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// No value
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -145,7 +145,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Contains a zero-length string or zero-length list.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -161,7 +161,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// List value
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -177,7 +177,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// String value
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -193,7 +193,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Int value
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -210,7 +210,7 @@ impl<'a, 'view> Rlp<'a> where 'a: 'view {
 	/// Get iterator over rlp-slices
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {

--- a/rlp/src/stream.rs
+++ b/rlp/src/stream.rs
@@ -61,7 +61,7 @@ impl RlpStream {
 	/// Appends value to the end of stream, chainable.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -99,7 +99,7 @@ impl RlpStream {
 	/// Declare appending the list of given size, chainable.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -149,7 +149,7 @@ impl RlpStream {
 	/// Apends null to the end of stream, chainable.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -215,7 +215,7 @@ impl RlpStream {
 	/// Clear the output stream so far.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {
@@ -237,7 +237,7 @@ impl RlpStream {
 	/// Returns true if stream doesnt expect any more items.
 	///
 	/// ```rust
-	/// extern crate rlp;
+	/// extern crate sputnikvm_rlp as rlp;
 	/// use rlp::*;
 	///
 	/// fn main () {

--- a/rlp/tests/tests.rs
+++ b/rlp/tests/tests.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate rlp;
+extern crate sputnikvm_rlp as rlp;
 
 use std::{fmt, cmp};
 use rlp::{Encodable, Decodable, UntrustedRlp, RlpStream, DecoderError};

--- a/sputnikvm/Cargo.toml
+++ b/sputnikvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.1.0"
+version = "0.2.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/sputnikvm/Cargo.toml
+++ b/sputnikvm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
+repository = "https://github.com/ethereumproject/sputnikvm"
 
 [lib]
 name = "sputnikvm"
@@ -16,5 +17,5 @@ ripemd160 = "0.5.2"
 sha2 = "0.5.3"
 digest = { version = "0.5", features = ["std"]}
 secp256k1 = "0.6.2"
-rlp = { path = '../rlp' }
-bigint = { path = '../bigint' }
+sputnikvm-rlp = { path = '../rlp' }
+sputnikvm-bigint = { path = '../bigint' }

--- a/sputnikvm/src/lib.rs
+++ b/sputnikvm/src/lib.rs
@@ -5,8 +5,8 @@
 
 extern crate log;
 extern crate tiny_keccak;
-extern crate rlp;
-extern crate bigint;
+extern crate sputnikvm_rlp as rlp;
+extern crate sputnikvm_bigint as bigint;
 extern crate ripemd160;
 extern crate sha2;
 extern crate secp256k1;


### PR DESCRIPTION
This makes sure we don't have Cargo name conflicts in
crates.io. Descriptions of Cargo.toml are also fixed.

(`sputnikvm-bigint = { path = "../bigint" }` will only be changed to `sputnikvm-bigint = "0.2.0"` in the release branch. The master branch will always use the `path` syntax for ease of development.)