### PR TITLE
Missing docs in the `sputnikvm` crate.

### DIFF
--- a/sputnikvm/src/lib.rs
+++ b/sputnikvm/src/lib.rs
@@ -1,3 +1,5 @@
+//! SputnikVM EVM implementation.
+
 #![deny(unused_import_braces, unused_imports,
         unused_comparisons, unused_must_use,
         unused_variables, non_shorthand_field_patterns,

--- a/sputnikvm/src/utils/bigint.rs
+++ b/sputnikvm/src/utils/bigint.rs
@@ -1,1 +1,2 @@
+//! Bigint re-export.
 pub use bigint::{M256, U256, MI256, U512, Sign, ParseHexError, read_hex};

--- a/sputnikvm/src/utils/opcode.rs
+++ b/sputnikvm/src/utils/opcode.rs
@@ -1,6 +1,7 @@
 //! Ethereum opcodes
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[allow(missing_docs)]
 /// Opcode enum. One-to-one corresponding to an `u8` value.
 pub enum Opcode {
     STOP, ADD, MUL, SUB, DIV, SDIV, MOD, SMOD, ADDMOD, MULMOD, EXP,

--- a/sputnikvm/src/vm/commit/account.rs
+++ b/sputnikvm/src/vm/commit/account.rs
@@ -15,21 +15,30 @@ pub enum AccountCommitment {
     /// should not change the account in other EVMs if it decides to
     /// accept the result.
     Full {
+        /// Nonce of the account.
         nonce: M256,
+        /// Account address.
         address: Address,
+        /// Account balance.
         balance: U256,
+        /// Code associated with this account.
         code: Vec<u8>,
     },
     /// Commit only code of the account. The client can keep changing
     /// it in other EVMs if the code remains unchanged.
     Code {
+        /// Account address.
         address: Address,
+        /// Code associated with this account.
         code: Vec<u8>,
     },
     /// Commit a storage. Must be used given a full account.
     Storage {
+        /// Account address.
         address: Address,
+        /// Account storage index.
         index: M256,
+        /// Value at the given account storage index.
         value: M256,
     },
     /// Indicate that an account does not exist.
@@ -62,23 +71,36 @@ impl AccountCommitment {
 pub enum Account {
     /// A full account. The client is expected to replace its own account state with this.
     Full {
+        /// Account nonce.
         nonce: M256,
+        /// Account address.
         address: Address,
+        /// Account balance.
         balance: U256,
+        /// Change storage with given indexes and values.
         changing_storage: Storage,
+        /// Code associated with this account.
         code: Vec<u8>,
     },
     /// Only balance is changed, and it is increasing for this address.
     IncreaseBalance(Address, U256),
     /// Only balance is changed, and it is decreasing for this address.
     DecreaseBalance(Address, U256),
-    /// Create a new account.
+    /// Create or delete a (new) account.
     Create {
+        /// Account nonce.
         nonce: M256,
+        /// Account address.
         address: Address,
+        /// Account balance.
         balance: U256,
+        /// All storage values of this account, with given indexes and values.
         storage: Storage,
+        /// Code associated with this account.
         code: Vec<u8>,
+        /// Whether, at this point, the account is considered
+        /// existing. The client should delete this address if this is
+        /// set to `false`.
         exists: bool,
     },
 }
@@ -260,6 +282,8 @@ impl AccountState {
         Ok(())
     }
 
+    /// Test whether an account at given address is considered
+    /// existing.
     pub fn exists(&self, address: Address) -> Result<bool, RequireError> {
         match self.accounts.get(&address) {
             Some(&Account::Create { exists, .. }) => Ok(exists),
@@ -268,6 +292,7 @@ impl AccountState {
         }
     }
 
+    /// Premark an address as exist.
     pub fn premark_exists(&mut self, address: Address) {
         match self.accounts.get_mut(&address) {
             Some(&mut Account::Full { .. }) => (),

--- a/sputnikvm/src/vm/errors.rs
+++ b/sputnikvm/src/vm/errors.rs
@@ -100,9 +100,21 @@ impl From<MachineError> for EvalError {
 /// Errors stating that the VM requires additional information to
 /// continue running.
 pub enum RequireError {
+    /// Requires the account at address for the VM to continue
+    /// running, this should usually be dealt by
+    /// `vm.commit_account(AccountCommitment::Full { .. })` or
+    /// `vm.commit_account(AccountCommitment::Nonexist(..))`.
     Account(Address),
+    /// Requires the account code at address for the VM to continue
+    /// running, this should usually be dealt by
+    /// `vm.commit_account(AccountCommitment::Code { .. })`.
     AccountCode(Address),
+    /// Requires the current value of the storage for the VM to
+    /// continue running, this should usually be dealt by
+    /// `vm.commit_account(AccountCommitment::Storage { .. }`.
     AccountStorage(Address, M256),
+    /// Requires the blockhash for the VM to continue running, this
+    /// should usually be dealt by `vm.commit_blockhash(..)`.
     Blockhash(M256),
 }
 
@@ -115,6 +127,8 @@ impl From<RequireError> for EvalError {
 #[derive(Debug, Clone)]
 /// Errors returned when committing a new information.
 pub enum CommitError {
+    /// The commitment is invalid.
     InvalidCommitment,
+    /// The commitment has already been committed.
     AlreadyCommitted,
 }

--- a/sputnikvm/src/vm/eval/mod.rs
+++ b/sputnikvm/src/vm/eval/mod.rs
@@ -19,36 +19,54 @@ mod precompiled;
 
 /// A VM state without PC.
 pub struct State<M> {
+    /// Memory of this runtime.
     pub memory: M,
+    /// Stack of this runtime.
     pub stack: Stack,
 
+    /// Context.
     pub context: Context,
+    /// Block header.
     pub block: BlockHeader,
+    /// Patch that is used by this runtime.
     pub patch: &'static Patch,
 
+    /// The current out value.
     pub out: Vec<u8>,
 
+    /// The current memory cost. Note that this is different from
+    /// memory gas.
     pub memory_cost: Gas,
+    /// Used gas excluding memory gas.
     pub used_gas: Gas,
+    /// Refunded gas.
     pub refunded_gas: Gas,
 
+    /// The current account commitment states.
     pub account_state: AccountState,
+    /// The current blockhash commitment states.
     pub blockhash_state: BlockhashState,
+    /// Logs appended.
     pub logs: Vec<Log>,
+    /// Removed accounts using the SUICIDE opcode.
     pub removed: Vec<Address>,
 
+    /// Depth of this runtime.
     pub depth: usize,
 }
 
 impl<M> State<M> {
+    /// Memory gas, part of total used gas.
     pub fn memory_gas(&self) -> Gas {
         memory_gas(self.memory_cost)
     }
 
+    /// Available gas at this moment.
     pub fn available_gas(&self) -> Gas {
         self.context.gas_limit - self.memory_gas() - self.used_gas
     }
 
+    /// Total used gas including the memory gas.
     pub fn total_used_gas(&self) -> Gas {
         self.memory_gas() + self.used_gas
     }
@@ -102,6 +120,7 @@ impl<M: Memory + Default> Machine<M> {
                           AccountState::default(), BlockhashState::default())
     }
 
+    /// Create a new runtime with the given states.
     pub fn with_states(context: Context, block: BlockHeader, patch: &'static Patch,
                        depth: usize, account_state: AccountState,
                        blockhash_state: BlockhashState) -> Self {

--- a/sputnikvm/src/vm/eval/precompiled.rs
+++ b/sputnikvm/src/vm/eval/precompiled.rs
@@ -1,3 +1,5 @@
+//! Functionality for precompiled accounts.
+
 use utils::address::Address;
 use utils::gas::Gas;
 
@@ -34,7 +36,9 @@ pub fn is_precompiled(address: Address) -> bool {
 }
 
 impl<M: Memory + Default> Machine<M> {
-    #[allow(unused_variables)]
+    /// Step a precompiled runtime. This function returns true if the
+    /// runtime is indeed a precompiled address. Otherwise return
+    /// false with state unchanged.
     pub fn step_precompiled(&mut self) -> bool {
         let ecrec_address = Address::from_str("0x0000000000000000000000000000000000000001").unwrap();
         let sha256_address = Address::from_str("0x0000000000000000000000000000000000000002").unwrap();

--- a/sputnikvm/src/vm/memory.rs
+++ b/sputnikvm/src/vm/memory.rs
@@ -8,9 +8,12 @@ use super::errors::MemoryError;
 /// fall.
 pub trait Memory {
     /// Check whether write on this index would result in an error. If
-    /// this function returns None, then both `write` and `write_raw`
-    /// on this index should succeed.
+    /// this function returns Ok, then both `write` and `write_raw` on
+    /// this index should succeed.
     fn check_write(&self, index: M256) -> Result<(), MemoryError>;
+    /// Check whether write on the given index range would result in
+    /// an error. If this function returns Ok, then both `write` and
+    /// `write_raw` on the given index range should succeed.
     fn check_write_range(&self, start: M256, len: M256) -> Result<(), MemoryError>;
 
     /// Write value into the index.

--- a/sputnikvm/src/vm/params.rs
+++ b/sputnikvm/src/vm/params.rs
@@ -7,23 +7,37 @@ use utils::bigint::{M256, U256};
 #[derive(Debug, Clone)]
 /// Block header.
 pub struct BlockHeader {
+    /// Block coinbase, the address that mines the block.
     pub coinbase: Address,
+    /// Block timestamp.
     pub timestamp: M256,
+    /// The current block number.
     pub number: M256,
+    /// Difficulty of the block.
     pub difficulty: M256,
+    /// Total block gas limit.
     pub gas_limit: Gas
 }
 
 #[derive(Debug, Clone)]
 /// A VM context. See the Yellow Paper for more information.
 pub struct Context {
+    /// Address that is executing this runtime.
     pub address: Address,
+    /// Caller of the runtime.
     pub caller: Address,
+    /// Code to be executed.
     pub code: Vec<u8>,
+    /// Data associated with this execution.
     pub data: Vec<u8>,
+    /// Gas limit.
     pub gas_limit: Gas,
+    /// Gas price.
     pub gas_price: Gas,
+    /// The origin of the context. The same as caller when it is from
+    /// a transaction.
     pub origin: Address,
+    /// Value passed for this runtime.
     pub value: U256,
 }
 
@@ -32,7 +46,10 @@ pub struct Context {
 /// execution. SputnikVM defer calculation of log bloom to the client,
 /// because VMs can run concurrently.
 pub struct Log {
+    /// Log appended to address.
     pub address: Address,
+    /// Log data.
     pub data: Vec<u8>,
+    /// Log topics.
     pub topics: Vec<M256>,
 }

--- a/sputnikvm/src/vm/patch.rs
+++ b/sputnikvm/src/vm/patch.rs
@@ -1,16 +1,32 @@
+//! Patch of a VM, indicating different hard-fork of the Ethereum
+//! block range.
+
+/// Represents different block range context.
 pub struct Patch {
+    /// Limit of the call stack.
     pub callstack_limit: usize,
+    /// Gas paid for extcode.
     pub gas_extcode: usize,
+    /// Gas paid for BALANCE opcode.
     pub gas_balance: usize,
+    /// Gas paid for SLOAD opcode.
     pub gas_sload: usize,
+    /// Gas paid for SUICIDE opcode.
     pub gas_suicide: usize,
+    /// Gas paid for SUICIDE opcode when it hits a new account.
     pub gas_suicide_new_account: usize,
+    /// Gas paid for CALL opcode.
     pub gas_call: usize,
+    /// Gas paid for EXP opcode for every byte.
     pub gas_expbyte: usize,
+    /// Gas paid for a contract creation transaction.
     pub gas_transaction_create: usize,
+    /// Whether to force code deposit even if it does not have enough
+    /// gas.
     pub force_code_deposit: bool,
 }
 
+/// Frontier patch.
 pub static FRONTIER_PATCH: Patch = Patch {
     callstack_limit: 1024,
     gas_extcode: 20,
@@ -24,6 +40,7 @@ pub static FRONTIER_PATCH: Patch = Patch {
     force_code_deposit: true,
 };
 
+/// Homestead patch.
 pub static HOMESTEAD_PATCH: Patch = Patch {
     callstack_limit: 1024,
     gas_extcode: 20,
@@ -37,6 +54,7 @@ pub static HOMESTEAD_PATCH: Patch = Patch {
     force_code_deposit: false,
 };
 
+/// Patch specific for the `jsontests` crate.
 pub static VMTEST_PATCH: Patch = Patch {
     callstack_limit: 2,
     gas_extcode: 20,
@@ -50,6 +68,7 @@ pub static VMTEST_PATCH: Patch = Patch {
     force_code_deposit: true,
 };
 
+/// EIP150 patch.
 pub static EIP150_PATCH: Patch = Patch {
     callstack_limit: 1024,
     gas_extcode: 700,
@@ -63,6 +82,7 @@ pub static EIP150_PATCH: Patch = Patch {
     force_code_deposit: false,
 };
 
+/// EIP160 patch.
 pub static EIP160_PATCH: Patch = Patch {
     callstack_limit: 1024,
     gas_extcode: 700,

--- a/sputnikvm/src/vm/pc.rs
+++ b/sputnikvm/src/vm/pc.rs
@@ -6,6 +6,7 @@ use std::cmp::min;
 use super::errors::PCError;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[allow(missing_docs)]
 /// Instructions for the program counter. This is the same as `Opcode`
 /// except `PUSH`, which might take longer length.
 pub enum Instruction {


### PR DESCRIPTION
This adds most of the missing docs so compiling `sputnikvm` does not
give any `missing_docs` warning.