### PR TITLE
Properly credit all SputnikVM contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,5 @@ Individual Copyright Statements
 
 Stewart Mackenzie
 Wei Tang
+Matt Brubeck
+Isaac Ardis

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sputnikvm"
 version = "0.4.0"
 license = "Apache-2.0"
-authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
+authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
 repository = "https://github.com/ethereumproject/sputnikvm"
 


### PR DESCRIPTION
This just deals with some aftermath because now Stewart has left this project.

I want to make sure that we have a proper way to credit everyone who's contributed to this project and also give incentives for community developers to become core members in this project.

I did a simple `git blame` through all files in the `src` subfolder and unfortunately it seems that Stewart wasn't getting a single line of code for the core SputnikVM library. Plus at least some developers look for authors field to send support emails, and Stewart probably does not want to receive any support emails for this crates.

This also added all people who's contributed code into the `AUTHORS` file.

I kept Stewart's name in `gethrpc` and `jsontests` crates as he has done some work for those two libraries.