### PR TITLE
CI: when deploy, display and upload sha256sum

### DIFF
--- a/.ci/before_deploy.sh
+++ b/.ci/before_deploy.sh
@@ -21,6 +21,8 @@ main() {
 
     cd $stage
     tar czf $src/sputnikvm-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz *
+    sha256sum $src/sputnikvm-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz
+    sha256sum $src/sputnikvm-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz > $src/sputnikvm-$TRAVIS_OS_NAME-$TRAVIS_TAG.tar.gz.sha256
     cd $src
 
     rm -rf $stage


### PR DESCRIPTION
Convenience for not requiring manually sign binaries for every release.