### PR TITLE
Use secp256k1-plus and upgrade etcommon to use 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,11 +1,17 @@
 [root]
-name = "sputnikvm-cli"
+name = "sputnikvm"
 version = "0.6.0"
 dependencies = [
- "clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gethrpc 0.6.0",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm 0.6.0",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-block 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-hexutil 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd160 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1-plus 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -60,8 +66,17 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "byte-tools"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -113,19 +128,10 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "digest-buffer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -143,20 +149,45 @@ dependencies = [
 
 [[package]]
 name = "etcommon-bigint"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "etcommon-rlp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "etcommon-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-hexutil 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "etcommon-block"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "etcommon-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-bloom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "etcommon-bloom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "etcommon-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "etcommon-hexutil"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "etcommon-rlp"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,11 +195,6 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "etcommon-util"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fake-simd"
@@ -187,11 +213,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "generic-array"
-version = "0.7.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "typenum 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -342,67 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-bigint 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-complex 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-rational 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.1.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-bigint 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,13 +447,13 @@ dependencies = [
 
 [[package]]
 name = "ripemd160"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -511,17 +476,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.6.2"
+name = "secp256k1-plus"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -555,14 +519,6 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde"
 version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -586,15 +542,6 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_json"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -606,29 +553,25 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "sputnikvm"
+name = "sha3"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "etcommon-bigint 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "etcommon-rlp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "etcommon-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd160 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "secp256k1 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -693,11 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "typenum"
-version = "1.5.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -786,23 +724,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30e93c03064e7590d0466209155251b90c22e37fab1daf2771582598b5827557"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum byte-tools 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0919189ba800c7ffe8778278116b7e0de3905ab81c72abb69c85cbfef7991279"
+"checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
 "checksum clap 2.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "867a885995b4184be051b70a592d4d70e32d7a188db6e8dff626af286a962771"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
-"checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"
-"checksum digest-buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4eb92364e9f6d3da159257250532d448b218406d2acb149f724e8f48e9f5cb9a"
+"checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum elastic-array 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71a64decd4b8cd06654a4e643c45cb558ad554abbffd82a7e16e34f45f51b605"
-"checksum etcommon-bigint 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "e80a2159db64f6429fc8dd420c300552858ecceb32684bec545e1dbf922bdbc8"
-"checksum etcommon-rlp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b52e92c28bbd6529c5f5b38c2bad36d7be48f62d59758126ac1532ba3747a7"
-"checksum etcommon-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e07dd5bcd3a7b9b5a1796e1d969cdebab0afb362ba7e534c6d9af6413af9648"
+"checksum etcommon-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "adc7974af1ac00bb6b0ece8f7d2d17af26c6707ab22e7c0cbf82ed69f8e41b6f"
+"checksum etcommon-block 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "314889516cd7bb96850bc101e8a9b5c92132c3101afea9294ee69c57fddda1f7"
+"checksum etcommon-bloom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "597fc8f5f8c6d62b03e6fe84301be5df0286eb17a1d325144131c2a079828a0f"
+"checksum etcommon-hexutil 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd4c1c493517ef0c97433c717329b62d8697806231be60c941678e8d45676f9"
+"checksum etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6c49be8eb8cd8adf87dca563106971d73de72371093c0f53119b68992d50bb19"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
-"checksum generic-array 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "330920f60726e8a1ca0129a40f0f0df0b8ee773945bf34895d578f35f31dc660"
+"checksum generic-array 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6181b378c58e5aacf4d3e17836737465cb2857750b53f6b46672a3509f2a8d9d"
 "checksum heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "556cd479866cf85c3f671209c85e8a6990211c916d1002c2fcb2e9b7cf60bc36"
 "checksum heapsize 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c7593b1522161003928c959c20a2ca421c68e940d63d75573316a009e48a6d4"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
@@ -819,12 +759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
 "checksum nodrop 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "52cd74cd09beba596430cc6e3091b74007169a56246e1262f0ba451ea95117b2"
-"checksum num 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "2c3a3dc9f30bf824141521b30c908a859ab190b76e20435fcd89f35eb6583887"
-"checksum num-bigint 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "6361748d02e5291c72a422dc8ed4d8464a80cb1e618971f6fffe6d52d97e3286"
-"checksum num-complex 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "412dfc143c56579aa6a22c574e38ddbf724522f1280ae2b257498cccff3fb6af"
-"checksum num-integer 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1a4bf6f9174aa5783a9b4cc892cacd11aebad6c69ad027a0b65c6ca5f8aa37"
-"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
-"checksum num-rational 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "33c881e104a26e1accc09449374c095ff2312c8e0c27fab7bbefe16eac7c776d"
 "checksum num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "1708c0628602a98b52fad936cf3edb9a107af06e52e49fdf0707e884456a6af6"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
@@ -835,20 +769,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a357d14a12e90a37d658725df0e6468504750b5948b9710f83f94a0c5818e8"
-"checksum ripemd160 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "62f5e9946b0762caf459b7accf86c40887ec2809b8dc892e1925f7d4b44b9eeb"
+"checksum ripemd160 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a347777d54218aec5d50f31ea04e8c0bceb1dea0282323f0cac42853178f07e9"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum schannel 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "14a5f8491ae5fc8c51aded1f5806282a0218b4d69b1b76913a0559507e559b90"
-"checksum secp256k1 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "89337332d12a98dd8f949f3fcfa5bc505783e9b620317ef1bbd89af7d4ca7302"
+"checksum secp256k1-plus 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "7222a0da4de37d12aa9d018c563f2916b40c3c5030292b9becde5825d86bf3e2"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"
 "checksum security-framework 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "42ddf098d78d0b64564b23ee6345d07573e7d10e52ad86875d89ddf5f8378a02"
 "checksum security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "5bacdada57ea62022500c457c8571c17dfb5e6240b7c8eac5916ffa8c7138a55"
-"checksum serde 0.6.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97b18e9e53de541f11e497357d6c5eaeb39f0cb9c8734e274abe4935f6991fa"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
 "checksum serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
-"checksum serde_json 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5aaee47e038bf9552d30380d3973fff2593ee0a76d81ad4c581f267cdcadf36"
 "checksum serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ad8bcf487be7d2e15d3d543f04312de991d631cfe1b43ea0ade69e6a8a5b16a1"
-"checksum sha2 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "84920f9ac881e94e33ec89e1b3dcd36040523a308a92548e01217ce35d8cf6a8"
+"checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
+"checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -856,10 +789,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum textwrap 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f86300c3e7416ee233abd7cda890c492007a3980f941f79185c753a701257167"
 "checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
-"checksum tiny-keccak 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b50173faa6ee499206f77b189d7ff3bef40f6969f228c9ec22b82080df9aa41"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-"checksum typenum 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7242a7857c31d13620847d78af39ecac8d6c90aac23286e84aefe624c77c9c14"
+"checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a2c4e3710edd365cd7e78383153ed739fa31af19f9172f72d3575060f5a43a"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,15 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 log = "0.3"
-tiny-keccak = "1.2"
-ripemd160 = "0.5.2"
-sha2 = "0.5.3"
-digest = { version = "0.5", features = ["std"]}
-secp256k1 = "0.6.2"
-etcommon-rlp = "0.1.1"
-etcommon-bigint = "0.1.14"
-etcommon-util = "0.1.0"
+ripemd160 = "0.6"
+sha2 = "0.6"
+sha3 = "0.6"
+digest = { version = "0.6", features = ["std"]}
+secp256k1-plus = "0.5.7"
+etcommon-block = "0.2"
+etcommon-rlp = "0.2"
+etcommon-bigint = "0.2"
+etcommon-hexutil = "0.2"
 
 [workspace]
 members = [

--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -1,4 +1,4 @@
-use sputnikvm::{Gas, M256, U256, Address, read_hex};
+use sputnikvm::{Gas, M256, U256, H256, Address, read_hex};
 use sputnikvm::vm::{Machine, Log, Context,
                     Account, Storage, AccountCommitment,
                     BlockHeader};
@@ -181,7 +181,7 @@ impl JSONBlock {
         v.insert(index, val);
     }
 
-    pub fn find_log(&self, address: Address, data: &[u8], topics: &[M256]) -> bool {
+    pub fn find_log(&self, address: Address, data: &[u8], topics: &[H256]) -> bool {
         for log in &self.logs {
             if log.address == address && log.data.as_slice() == data && log.topics.as_slice() == topics {
                 return true;

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -7,7 +7,7 @@ pub use self::blockchain::{JSONBlock, create_block, create_context};
 
 use serde_json::Value;
 use std::str::FromStr;
-use sputnikvm::{Gas, M256, U256, Address, read_hex};
+use sputnikvm::{Gas, M256, U256, H256, Address, read_hex};
 use sputnikvm::vm::errors::RequireError;
 use sputnikvm::vm::{VM, SeqContextVM, AccountCommitment, Context, Account, Storage, Patch, VMStatus, VMTEST_PATCH};
 
@@ -221,10 +221,10 @@ pub fn test_machine(v: &Value, machine: &SeqContextVM, block: &JSONBlock, debug:
 
             let address = Address::from_str(log["address"].as_str().unwrap()).unwrap();
             let data = read_hex(log["data"].as_str().unwrap()).unwrap();
-            let mut topics: Vec<M256> = Vec::new();
+            let mut topics: Vec<H256> = Vec::new();
 
             for topic in log["topics"].as_array().unwrap() {
-                topics.push(M256::from_str(topic.as_str().unwrap()).unwrap());
+                topics.push(H256::from_str(topic.as_str().unwrap()).unwrap());
             }
 
             if !block.find_log(address, data.as_slice(), topics.as_slice()) {

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -12,7 +12,7 @@ use std::io::{BufReader};
 use std::str::FromStr;
 use std::collections::{HashMap, HashSet};
 
-use sputnikvm::{Gas, Address, U256, M256, read_hex};
+use sputnikvm::{Gas, Address, U256, M256, H256, read_hex};
 use sputnikvm::vm::{BlockHeader, Context, SeqTransactionVM, Transaction, VM, Log, Patch,
                     AccountCommitment, Account, FRONTIER_PATCH, HOMESTEAD_PATCH,
                     EIP150_PATCH, EIP160_PATCH};
@@ -51,9 +51,9 @@ fn from_rpc_transaction(transaction: &RPCTransaction) -> Transaction {
 }
 
 fn from_rpc_log(log: &RPCLog) -> Log {
-    let mut topics: Vec<M256> = Vec::new();
+    let mut topics: Vec<H256> = Vec::new();
     for topic in &log.topics {
-        topics.push(M256::from_str(&topic).unwrap());
+        topics.push(H256::from_str(&topic).unwrap());
     }
     Log {
         address: Address::from_str(&log.address).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,19 +6,20 @@
         unreachable_code)]
 
 extern crate log;
-extern crate tiny_keccak;
-extern crate etcommon_rlp as rlp;
-extern crate etcommon_bigint as bigint;
-extern crate etcommon_util;
+extern crate rlp;
+extern crate bigint;
+extern crate hexutil;
+extern crate block;
 extern crate ripemd160;
 extern crate sha2;
+extern crate sha3;
 extern crate secp256k1;
 extern crate digest;
 
 mod util;
 pub mod vm;
 
-pub use util::bigint::{U256, M256, MI256};
+pub use util::bigint::{U256, M256, H256, MI256};
 pub use util::gas::Gas;
 pub use util::address::Address;
 pub use util::opcode::Opcode;

--- a/src/util/bigint.rs
+++ b/src/util/bigint.rs
@@ -1,2 +1,2 @@
 //! Bigint re-export.
-pub use bigint::{M256, U256, MI256, U512, Sign};
+pub use bigint::{M256, U256, MI256, U512, H256, Sign};

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,4 +4,4 @@ pub mod address;
 pub mod gas;
 pub mod opcode;
 
-pub use etcommon_util::{read_hex, ParseHexError};
+pub use hexutil::{read_hex, ParseHexError};

--- a/src/vm/params.rs
+++ b/src/vm/params.rs
@@ -43,15 +43,4 @@ pub struct Context {
     pub apprent_value: U256,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-/// Additional logs to be added due to the current VM
-/// execution. SputnikVM defer calculation of log bloom to the client,
-/// because VMs can run concurrently.
-pub struct Log {
-    /// Log appended to address.
-    pub address: Address,
-    /// Log data.
-    pub data: Vec<u8>,
-    /// Log topics.
-    pub topics: Vec<M256>,
-}
+pub use block::Log;

--- a/src/vm/transaction.rs
+++ b/src/vm/transaction.rs
@@ -6,7 +6,7 @@ use util::gas::Gas;
 use util::address::Address;
 use util::bigint::{U256, M256};
 use rlp::RlpStream;
-use tiny_keccak::Keccak;
+use sha3::{Digest, Keccak256};
 
 use super::errors::{RequireError, CommitError};
 use super::{Context, ContextVM, VM, AccountState, BlockhashState, Patch, BlockHeader, Memory,
@@ -67,12 +67,9 @@ impl Transaction {
                 let mut rlp = RlpStream::new_list(2);
                 rlp.append(&caller);
                 rlp.append(&nonce);
-                let mut address_array = [0u8; 32];
-                let mut sha3 = Keccak::new_keccak256();
-                sha3.update(rlp.out().as_slice());
-                sha3.finalize(&mut address_array);
 
-                Ok(Address::from(M256::from(address_array.as_ref())))
+                let address = Address::from(M256::from(Keccak256::digest(rlp.out().as_slice()).as_slice()));
+                Ok(address)
             },
         }
     }


### PR DESCRIPTION
`secp256k1-plus` has the singleton feature which is really useful for
performance. Changed from `tiny_keccak` to `sha3` due to `sha2` and
`ripemd`'s dependency on `digest`. Upgrade `etcommon`s dependency to
`0.2` and use `etcommon-block`'s `Log` struct.