### PR TITLE
stateful, parallel: Add used_addresses and use that for conflict check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.6.1"
+version = "0.6.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/src/vm/commit/account.rs
+++ b/src/vm/commit/account.rs
@@ -142,6 +142,18 @@ impl Default for AccountState {
 }
 
 impl AccountState {
+    /// Returns all fetched or modified addresses.
+    pub fn used_addresses(&self) -> HashSet<Address> {
+        let mut set = HashSet::new();
+        for account in self.accounts() {
+            set.insert(account.address());
+        }
+        for (address, _) in &self.codes {
+            set.insert(*address);
+        }
+        set
+    }
+
     /// Returns all accounts right now in this account state.
     pub fn accounts(&self) -> hash_map::Values<Address, Account> {
         self.accounts.values()

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -32,7 +32,7 @@ pub use self::eval::{State, Machine, MachineStatus};
 pub use self::commit::{AccountCommitment, Account, AccountState, BlockhashState};
 pub use self::transaction::{ValidTransaction, TransactionVM};
 
-use std::collections::hash_map;
+use std::collections::{HashSet, hash_map};
 use util::bigint::{U256, H256};
 use util::gas::Gas;
 use util::address::Address;
@@ -80,6 +80,8 @@ pub trait VM {
     /// Returns the changed or committed accounts information up to
     /// current execution status.
     fn accounts(&self) -> hash_map::Values<Address, Account>;
+    /// Returns all fetched or modified addresses.
+    fn used_addresses(&self) -> HashSet<Address>;
     /// Returns the out value, if any.
     fn out(&self) -> &[u8];
     /// Returns the available gas of this VM.
@@ -208,6 +210,10 @@ impl<M: Memory + Default> VM for ContextVM<M> {
 
     fn accounts(&self) -> hash_map::Values<Address, Account> {
         self.machines[0].state().account_state.accounts()
+    }
+
+    fn used_addresses(&self) -> HashSet<Address> {
+        self.machines[0].state().account_state.used_addresses()
     }
 
     fn out(&self) -> &[u8] {

--- a/src/vm/transaction.rs
+++ b/src/vm/transaction.rs
@@ -1,6 +1,6 @@
 //! Transaction related functionality.
 
-use std::collections::hash_map;
+use std::collections::{HashSet, hash_map};
 use std::cmp::min;
 use std::str::FromStr;
 use util::gas::Gas;
@@ -376,6 +376,13 @@ impl<M: Memory + Default> VM for TransactionVM<M> {
         match self.0 {
             TransactionVMState::Running { ref vm, .. } => vm.accounts(),
             TransactionVMState::Constructing { ref account_state, .. } => account_state.accounts(),
+        }
+    }
+
+    fn used_addresses(&self) -> HashSet<Address> {
+        match self.0 {
+            TransactionVMState::Running { ref vm, .. } => vm.used_addresses(),
+            TransactionVMState::Constructing { ref account_state, .. } => account_state.used_addresses(),
         }
     }
 


### PR DESCRIPTION
The VM might only fetch a code from the state root. In that case, it
is not included in vm.accounts(). However, it should still be counted
as used address because a contract creation transaction may modify it.