### PR TITLE
Incorrect SeqMemory len definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.7.3"
+version = "0.7.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -42,15 +42,6 @@ impl Default for SeqMemory {
 
 impl SeqMemory {
     pub fn len(&self) -> usize {
-        let len = self.memory.len();
-        if len % 32 == 0 {
-            len / 32
-        } else {
-            len / 32 + 1
-        }
-    }
-
-    pub fn raw_len(&self) -> usize {
         self.memory.len()
     }
 }


### PR DESCRIPTION
Memory is always u8-indexed so len should always be the raw len.