### PR TITLE
Distingish OnChainError and NotSupportedError

### DIFF
--- a/gethrpc/Cargo.toml
+++ b/gethrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gethrpc"
-version = "0.6.0"
+version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "gethrpc - provides functionality for interacting with geth's blockchain."

--- a/jsontests/Cargo.toml
+++ b/jsontests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsontests"
-version = "0.6.0"
+version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 

--- a/regtests/Cargo.toml
+++ b/regtests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regtests"
-version = "0.6.0"
+version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "regtests - performs a regression test of the entire ethereum classic blockchain."

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,94 +16,109 @@ pub enum PreExecutionError {
 }
 
 #[derive(Debug, Clone)]
-/// Errors returned by an EVM memory.
-pub enum MemoryError {
-    /// The index is too large for the implementation of the VM to
-    /// handle.
-    IndexNotSupported,
-}
-
-impl From<MemoryError> for MachineError {
-    fn from(val: MemoryError) -> MachineError {
-        MachineError::Memory(val)
-    }
-}
-
-impl From<MemoryError> for EvalError {
-    fn from(val: MemoryError) -> EvalError {
-        EvalError::Machine(MachineError::Memory(val))
-    }
-}
-
-#[derive(Debug, Clone)]
-/// Errors returned by an EVM stack.
-pub enum StackError {
+pub enum OnChainError {
     /// Stack is overflowed (pushed more than 1024 items to the
     /// stack).
-    Overflow,
+    StackOverflow,
     /// Stack is underflowed (poped an empty stack).
-    Underflow,
-}
-
-impl From<StackError> for EvalError {
-    fn from(val: StackError) -> EvalError {
-        EvalError::Machine(MachineError::Stack(val))
-    }
-}
-
-#[derive(Debug, Clone)]
-/// Errors returned by an EVM PC.
-pub enum PCError {
+    StackUnderflow,
     /// The opcode is invalid and the PC is not able to convert it to
     /// an instruction.
     InvalidOpcode,
-    /// The index is too large for the implementation of the VM to
-    /// handle.
-    IndexNotSupported,
     /// PC jumped to an invalid jump destination.
     BadJumpDest,
     /// PC overflowed (tries to read the next opcode which is already
-    /// the end of the code).
-    Overflow,
+    /// the end of the code). In Yellow Paper, this is categorized the
+    /// same as InvalidOpcode.
+    PCOverflow,
+    /// Not enough gas to continue.
+    EmptyGas,
+    /// For instruction that requires reading a range, it is
+    /// invalid. This in the Yellow Paper is covered by EmptyGas.
+    InvalidRange,
 }
 
-impl From<PCError> for EvalError {
-    fn from(val: PCError) -> EvalError {
-        EvalError::Machine(MachineError::PC(val))
+impl From<OnChainError> for RuntimeError {
+    fn from(val: OnChainError) -> RuntimeError {
+        RuntimeError::OnChain(val)
+    }
+}
+
+impl From<OnChainError> for EvalOnChainError {
+    fn from(val: OnChainError) -> EvalOnChainError {
+        EvalOnChainError::OnChain(val)
+    }
+}
+
+impl From<OnChainError> for EvalError {
+    fn from(val: OnChainError) -> EvalError {
+        EvalError::OnChain(val)
     }
 }
 
 #[derive(Debug, Clone)]
-/// Errors returned when trying to step the instruction.
-pub enum EvalError {
-    /// A runtime error. Non-recoverable.
-    Machine(MachineError),
-    /// The VM requires account of blockhash information to be
-    /// committed. Recoverable after the required information is
-    /// committed.
+pub enum NotSupportedError {
+    /// The PC index is too large for the implementation of the VM to
+    /// handle.
+    PCIndexNotSupported,
+    /// The memory index is too large for the implementation of the VM to
+    /// handle.
+    MemoryIndexNotSupported,
+}
+
+impl From<NotSupportedError> for RuntimeError {
+    fn from(val: NotSupportedError) -> RuntimeError {
+        RuntimeError::NotSupported(val)
+    }
+}
+
+impl From<NotSupportedError> for EvalError {
+    fn from(val: NotSupportedError) -> EvalError {
+        EvalError::NotSupported(val)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum RuntimeError {
+    /// On chain error.
+    OnChain(OnChainError),
+    /// Off chain error due to VM not supported.
+    NotSupported(NotSupportedError),
+}
+
+impl From<RuntimeError> for EvalError {
+    fn from(val: RuntimeError) -> EvalError {
+        match val {
+            RuntimeError::OnChain(err) =>
+                EvalError::OnChain(err),
+            RuntimeError::NotSupported(err) =>
+                EvalError::NotSupported(err),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum EvalOnChainError {
+    OnChain(OnChainError),
     Require(RequireError),
 }
 
-#[derive(Debug, Clone)]
-/// Errors returned by the a single machine of the VM.
-pub enum MachineError {
-    /// VM memory error.
-    Memory(MemoryError),
-    /// VM stack error.
-    Stack(StackError),
-    /// VM PC error.
-    PC(PCError),
-
-    /// For instruction that requires reading a range, it is invalid.
-    InvalidRange,
-    /// Not enough gas to continue.
-    EmptyGas,
+impl From<EvalOnChainError> for EvalError {
+    fn from(val: EvalOnChainError) -> EvalError {
+        match val {
+            EvalOnChainError::OnChain(err) =>
+                EvalError::OnChain(err),
+            EvalOnChainError::Require(err) =>
+                EvalError::Require(err),
+        }
+    }
 }
 
-impl From<MachineError> for EvalError {
-    fn from(val: MachineError) -> EvalError {
-        EvalError::Machine(val)
-    }
+#[derive(Debug, Clone)]
+pub enum EvalError {
+    OnChain(OnChainError),
+    NotSupported(NotSupportedError),
+    Require(RequireError),
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +146,12 @@ pub enum RequireError {
 impl From<RequireError> for EvalError {
     fn from(val: RequireError) -> EvalError {
         EvalError::Require(val)
+    }
+}
+
+impl From<RequireError> for EvalOnChainError {
+    fn from(val: RequireError) -> EvalOnChainError {
+        EvalOnChainError::Require(val)
     }
 }
 

--- a/src/eval/check.rs
+++ b/src/eval/check.rs
@@ -3,17 +3,17 @@
 use bigint::{U256, M256, Gas};
 
 use ::{Memory, Instruction, Patch};
-use errors::{MachineError, EvalError};
+use errors::{OnChainError, NotSupportedError, EvalOnChainError};
 use eval::{State, ControlCheck};
 
 use super::util::check_range;
 
 #[allow(unused_variables)]
-pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), EvalError> {
+pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), OnChainError> {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE | Instruction::DELEGATECALL => {
             if P::err_on_call_with_more_gas() && after_gas < state.stack.peek(0).unwrap().into() {
-                Err(EvalError::Machine(MachineError::EmptyGas))
+                Err(OnChainError::EmptyGas)
             } else {
                 Ok(())
             }
@@ -22,10 +22,54 @@ pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instructio
     }
 }
 
+pub fn check_support<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Result<(), NotSupportedError> {
+    match instruction {
+        Instruction::MSTORE => {
+            state.memory.check_write(state.stack.peek(0).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::MSTORE8 => {
+            state.memory.check_write(state.stack.peek(0).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::CALLDATACOPY => {
+            state.memory.check_write_range(
+                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::CODECOPY => {
+            state.memory.check_write_range(
+                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::EXTCODECOPY => {
+            state.memory.check_write_range(
+                state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::CALL => {
+            state.memory.check_write_range(
+                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::CALLCODE => {
+            state.memory.check_write_range(
+                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            Ok(())
+        },
+        Instruction::DELEGATECALL => {
+            state.memory.check_write_range(
+                state.stack.peek(4).unwrap().into(), state.stack.peek(5).unwrap().into())?;
+            Ok(())
+        },
+        _ => Ok(()),
+    }
+}
+
 #[allow(unused_variables)]
 /// Check whether `run_opcode` would fail without mutating any of the
 /// machine state.
-pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Result<Option<ControlCheck>, EvalError> {
+pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Result<Option<ControlCheck>, EvalOnChainError> {
     match instruction {
         Instruction::STOP => Ok(None),
         Instruction::ADD => { state.stack.check_pop_push(2, 1)?; Ok(None) },
@@ -71,15 +115,13 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALLDATASIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CALLDATACOPY => {
             state.stack.check_pop_push(3, 0)?;
-            state.memory.check_write_range(
-                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(None)
         },
         Instruction::CODESIZE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
         Instruction::CODECOPY => {
             state.stack.check_pop_push(3, 0)?;
-            state.memory.check_write_range(
-                state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
+            check_range(state.stack.peek(0).unwrap().into(), state.stack.peek(2).unwrap().into())?;
             Ok(None)
         },
         Instruction::GASPRICE => { state.stack.check_pop_push(0, 1)?; Ok(None) },
@@ -91,8 +133,7 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::EXTCODECOPY => {
             state.stack.check_pop_push(4, 0)?;
             state.account_state.require_code(state.stack.peek(0).unwrap().into())?;
-            state.memory.check_write_range(
-                state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
+            check_range(state.stack.peek(1).unwrap().into(), state.stack.peek(3).unwrap().into())?;
             Ok(None)
         },
 
@@ -115,12 +156,10 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::MLOAD => { state.stack.check_pop_push(1, 1)?; Ok(None) },
         Instruction::MSTORE => {
             state.stack.check_pop_push(2, 0)?;
-            state.memory.check_write(state.stack.peek(0).unwrap().into())?;
             Ok(None)
         },
         Instruction::MSTORE8 => {
             state.stack.check_pop_push(2, 0)?;
-            state.memory.check_write(state.stack.peek(0).unwrap().into())?;
             Ok(None)
         },
         Instruction::SLOAD => {
@@ -171,8 +210,7 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALL => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap().into(), state.stack.peek(4).unwrap().into())?;
-            state.memory.check_write_range(
-                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            check_range(state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
@@ -180,8 +218,7 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::CALLCODE => {
             state.stack.check_pop_push(7, 1)?;
             check_range(state.stack.peek(3).unwrap().into(), state.stack.peek(4).unwrap().into())?;
-            state.memory.check_write_range(
-                state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
+            check_range(state.stack.peek(5).unwrap().into(), state.stack.peek(6).unwrap().into())?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)
@@ -194,8 +231,7 @@ pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State
         Instruction::DELEGATECALL => {
             state.stack.check_pop_push(6, 1)?;
             check_range(state.stack.peek(2).unwrap().into(), state.stack.peek(3).unwrap().into())?;
-            state.memory.check_write_range(
-                state.stack.peek(4).unwrap().into(), state.stack.peek(5).unwrap().into())?;
+            check_range(state.stack.peek(4).unwrap().into(), state.stack.peek(5).unwrap().into())?;
             state.account_state.require(state.context.address)?;
             state.account_state.require(state.stack.peek(1).unwrap().into())?;
             Ok(None)

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Runtime lifecycle related functionality.
 
 use bigint::{U256, M256, Gas};
-use errors::{RequireError, MachineError};
+use errors::{RequireError, OnChainError};
 use commit::AccountState;
 use ::{Memory, Patch};
 use super::{Machine, MachineStatus};
@@ -79,7 +79,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         let deposit_cost = code_deposit_gas(self.state.out.len());
         if deposit_cost > self.state.available_gas() {
             if !P::force_code_deposit() {
-                self.status = MachineStatus::ExitedErr(MachineError::EmptyGas);
+                self.status = MachineStatus::ExitedErr(OnChainError::EmptyGas);
             } else {
                 self.state.account_state.code_deposit(self.state.context.address, &[]);
             }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -238,7 +238,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
             return Ok(());
         }
 
-        let instruction = match self.pc.read() {
+        let instruction = match self.pc.peek() {
             Ok(val) => val,
             Err(RuntimeError::OnChain(err)) => {
                 self.status = MachineStatus::ExitedErr(err);

--- a/src/eval/util.rs
+++ b/src/eval/util.rs
@@ -2,16 +2,16 @@
 
 use bigint::{U256, M256, Gas};
 use ::Memory;
-use errors::MachineError;
+use errors::OnChainError;
 use std::cmp::min;
 
 pub fn l64(gas: Gas) -> Gas {
     gas - gas / Gas::from(64u64)
 }
 
-pub fn check_range(start: U256, len: U256) -> Result<(), MachineError> {
+pub fn check_range(start: U256, len: U256) -> Result<(), OnChainError> {
     if M256::from(start) + M256::from(len) < M256::from(start) {
-        Err(MachineError::InvalidRange)
+        Err(OnChainError::InvalidRange)
     } else {
         Ok(())
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,7 +2,7 @@
 
 use bigint::{U256, M256};
 
-use super::errors::MemoryError;
+use super::errors::NotSupportedError;
 
 /// Represent a memory in EVM. Read should always succeed. Write can
 /// fall.
@@ -10,16 +10,16 @@ pub trait Memory {
     /// Check whether write on this index would result in an error. If
     /// this function returns Ok, then both `write` and `write_raw` on
     /// this index should succeed.
-    fn check_write(&self, index: U256) -> Result<(), MemoryError>;
+    fn check_write(&self, index: U256) -> Result<(), NotSupportedError>;
     /// Check whether write on the given index range would result in
     /// an error. If this function returns Ok, then both `write` and
     /// `write_raw` on the given index range should succeed.
-    fn check_write_range(&self, start: U256, len: U256) -> Result<(), MemoryError>;
+    fn check_write_range(&self, start: U256, len: U256) -> Result<(), NotSupportedError>;
 
     /// Write value into the index.
-    fn write(&mut self, index: U256, value: M256) -> Result<(), MemoryError>;
+    fn write(&mut self, index: U256, value: M256) -> Result<(), NotSupportedError>;
     /// Write only one byte value into the index.
-    fn write_raw(&mut self, index: U256, value: u8) -> Result<(), MemoryError>;
+    fn write_raw(&mut self, index: U256, value: u8) -> Result<(), NotSupportedError>;
     /// Read value from the index.
     fn read(&self, index: U256) -> M256;
     /// Read only one byte value from the index.
@@ -47,31 +47,31 @@ impl SeqMemory {
 }
 
 impl Memory for SeqMemory {
-    fn check_write(&self, index: U256) -> Result<(), MemoryError> {
+    fn check_write(&self, index: U256) -> Result<(), NotSupportedError> {
         let end = index + 32.into();
         if end > U256::from(usize::max_value()) {
-            Err(MemoryError::IndexNotSupported)
+            Err(NotSupportedError::MemoryIndexNotSupported)
         } else {
             Ok(())
         }
     }
 
-    fn check_write_range(&self, start: U256, len: U256) -> Result<(), MemoryError> {
+    fn check_write_range(&self, start: U256, len: U256) -> Result<(), NotSupportedError> {
         if len == U256::zero() {
             return Ok(());
         }
 
         if M256::from(start) + M256::from(len) < M256::from(start) {
-            Err(MemoryError::IndexNotSupported)
+            Err(NotSupportedError::MemoryIndexNotSupported)
         } else {
             self.check_write(start + len - U256::from(1u64))
         }
     }
 
-    fn write(&mut self, index: U256, value: M256) -> Result<(), MemoryError> {
+    fn write(&mut self, index: U256, value: M256) -> Result<(), NotSupportedError> {
         let end = M256::from(index) + 32.into();
         if end > M256::from(usize::max_value()) {
-            return Err(MemoryError::IndexNotSupported);
+            return Err(NotSupportedError::MemoryIndexNotSupported);
         }
 
         for i in 0..32 {
@@ -80,9 +80,9 @@ impl Memory for SeqMemory {
         Ok(())
     }
 
-    fn write_raw(&mut self, index: U256, value: u8) -> Result<(), MemoryError> {
+    fn write_raw(&mut self, index: U256, value: u8) -> Result<(), NotSupportedError> {
         if index > U256::from(usize::max_value()) {
-            return Err(MemoryError::IndexNotSupported);
+            return Err(NotSupportedError::MemoryIndexNotSupported);
         }
 
         let index: usize = index.as_usize();

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -1,7 +1,7 @@
 use bigint::Gas;
 use std::cmp::min;
 
-use errors::MachineError;
+use errors::{RuntimeError, OnChainError};
 use sha2::Sha256;
 use sha3::Keccak256;
 use ripemd160::Ripemd160;
@@ -19,10 +19,10 @@ pub trait Precompiled: Sync {
         unimplemented!()
     }
     /// Combine step and gas together, given the gas limit.
-    fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Vec<u8>), MachineError> {
+    fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Vec<u8>), RuntimeError> {
         let gas = self.gas(data);
         if gas > gas_limit {
-            Err(MachineError::EmptyGas)
+            Err(RuntimeError::OnChain(OnChainError::EmptyGas))
         } else {
             Ok((gas, self.step(data)))
         }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,7 +1,7 @@
 //! EVM stack
 
 use bigint::M256;
-use super::errors::StackError;
+use super::errors::OnChainError;
 
 /// Represents an EVM stack.
 pub struct Stack {
@@ -19,56 +19,56 @@ impl Default for Stack {
 impl Stack {
     /// Check a pop-push cycle. If the check succeeded, `push`, `pop`,
     /// `set`, `peek` within the limit should not fail.
-    pub fn check_pop_push(&self, pop: usize, push: usize) -> Result<(), StackError> {
+    pub fn check_pop_push(&self, pop: usize, push: usize) -> Result<(), OnChainError> {
         if self.len() < pop {
-            return Err(StackError::Underflow);
+            return Err(OnChainError::StackUnderflow);
         }
         if self.len() - pop + push > 1024 {
-            return Err(StackError::Overflow);
+            return Err(OnChainError::StackOverflow);
         }
         Ok(())
     }
 
     /// Push a new value to the stack.
-    pub fn push(&mut self, elem: M256) -> Result<(), StackError> {
+    pub fn push(&mut self, elem: M256) -> Result<(), OnChainError> {
         self.stack.push(elem);
         if self.len() > 1024 {
             self.stack.pop();
-            Err(StackError::Overflow)
+            Err(OnChainError::StackOverflow)
         } else {
             Ok(())
         }
     }
 
     /// Pop a value from the stack.
-    pub fn pop(&mut self) -> Result<M256, StackError> {
+    pub fn pop(&mut self) -> Result<M256, OnChainError> {
         match self.stack.pop() {
             Some(x) => Ok(x),
-            None => Err(StackError::Underflow),
+            None => Err(OnChainError::StackUnderflow),
         }
     }
 
     /// Set a value at given index for the stack, where the top of the
     /// stack is at index `0`. If the index is too large,
     /// `StackError::Underflow` is returned.
-    pub fn set(&mut self, no_from_top: usize, val: M256) -> Result<(), StackError> {
+    pub fn set(&mut self, no_from_top: usize, val: M256) -> Result<(), OnChainError> {
         if self.stack.len() > no_from_top {
             let len = self.stack.len();
             self.stack[len - no_from_top - 1] = val;
             Ok(())
         } else {
-            Err(StackError::Underflow)
+            Err(OnChainError::StackUnderflow)
         }
     }
 
     /// Peek a value at given index for the stack, where the top of
     /// the stack is at index `0`. If the index is too large,
     /// `StackError::Underflow` is returned.
-    pub fn peek(&self, no_from_top: usize) -> Result<M256, StackError> {
+    pub fn peek(&self, no_from_top: usize) -> Result<M256, OnChainError> {
         if self.stack.len() > no_from_top {
             Ok(self.stack[self.stack.len() - no_from_top - 1])
         } else {
-            Err(StackError::Underflow)
+            Err(OnChainError::StackUnderflow)
         }
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -321,6 +321,9 @@ impl<M: Memory + Default, P: Patch> VM for TransactionVM<M, P> {
                     VMStatus::Running => {
                         return vm.step();
                     },
+                    VMStatus::ExitedNotSupported(_) => {
+                        return Ok(());
+                    },
                     _ => {
                         if *code_deposit {
                             vm.machines[0].code_deposit();


### PR DESCRIPTION
This refactors the error mod to distinguish:

* OnChainError: errors that are agreed upon all EVMs. If this EVM returns a error in this category, all VMs return an error.
* NotSupportedError: errors that indicate that this EVM cannot know the result due to resources limitation, usually due to using too much memory (more than u64::max_size()) or the code is too long. This practically cannot happen, while it is still possible to create fake block header parameters to trick this EVM to get this result.