### PR TITLE
Fix a bug in PC and implement Patch::memory_limit

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,9 +58,6 @@ impl From<OnChainError> for EvalError {
 
 #[derive(Debug, Clone)]
 pub enum NotSupportedError {
-    /// The PC index is too large for the implementation of the VM to
-    /// handle.
-    PCIndexNotSupported,
     /// The memory index is too large for the implementation of the VM to
     /// handle.
     MemoryIndexNotSupported,

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -240,12 +240,8 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
 
         let instruction = match self.pc.peek() {
             Ok(val) => val,
-            Err(RuntimeError::OnChain(err)) => {
+            Err(err) => {
                 self.status = MachineStatus::ExitedErr(err);
-                return Ok(())
-            },
-            Err(RuntimeError::NotSupported(err)) => {
-                self.status = MachineStatus::ExitedNotSupported(err);
                 return Ok(())
             },
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,10 @@ pub trait VM {
 
 /// A sequencial VM. It uses sequencial memory representation and hash
 /// map storage for accounts.
-pub type SeqContextVM<P> = ContextVM<SeqMemory, P>;
+pub type SeqContextVM<P> = ContextVM<SeqMemory<P>, P>;
 /// A sequencial transaction VM. This is same as `SeqContextVM` except
 /// it runs at transaction level.
-pub type SeqTransactionVM<P> = TransactionVM<SeqMemory, P>;
+pub type SeqTransactionVM<P> = TransactionVM<SeqMemory<P>, P>;
 
 /// A VM that executes using a context and block information.
 pub struct ContextVM<M, P: Patch> {

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -41,6 +41,8 @@ pub trait Patch {
     /// If true, only consume at maximum l64(after_gas) when
     /// CALL/CALLCODE/DELEGATECALL.
     fn call_create_l64_after_gas() -> bool;
+    /// Maximum size of the memory, in bytes.
+    fn memory_limit() -> usize;
     /// Precompiled contracts at given address, with required code,
     /// and its definition.
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)];
@@ -79,6 +81,7 @@ impl Patch for FrontierPatch {
     fn has_delegate_call() -> bool { false }
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
         ETC_PRECOMPILEDS.deref() }
 }
@@ -99,6 +102,7 @@ impl Patch for HomesteadPatch {
     fn has_delegate_call() -> bool { true }
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
         ETC_PRECOMPILEDS.deref() }
 }
@@ -119,6 +123,7 @@ impl Patch for VMTestPatch {
     fn has_delegate_call() -> bool { false }
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
         ETC_PRECOMPILEDS.deref() }
 }
@@ -139,6 +144,7 @@ impl Patch for EIP150Patch {
     fn has_delegate_call() -> bool { true }
     fn err_on_call_with_more_gas() -> bool { false }
     fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
         ETC_PRECOMPILEDS.deref() }
 }
@@ -159,6 +165,7 @@ impl Patch for EIP160Patch {
     fn has_delegate_call() -> bool { true }
     fn err_on_call_with_more_gas() -> bool { false }
     fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
         ETC_PRECOMPILEDS.deref() }
 }

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -5,7 +5,7 @@ use util::opcode::Opcode;
 use std::cmp::min;
 use std::marker::PhantomData;
 use super::Patch;
-use super::errors::{OnChainError, NotSupportedError, RuntimeError};
+use super::errors::{OnChainError, RuntimeError};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)]
@@ -72,10 +72,7 @@ impl<P: Patch> PC<P> {
             return Err(RuntimeError::OnChain(OnChainError::PCOverflow));
         }
         let position = from_position;
-        if position.checked_add(byte_count).is_none() {
-            return Err(RuntimeError::NotSupported(NotSupportedError::PCIndexNotSupported));
-        }
-        let max = min(position + byte_count, self.code.len());
+        let max = min(position.saturating_add(byte_count), self.code.len());
         Ok(M256::from(&self.code[position..max]))
     }
 

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -5,7 +5,7 @@ use util::opcode::Opcode;
 use std::cmp::min;
 use std::marker::PhantomData;
 use super::Patch;
-use super::errors::{OnChainError, RuntimeError};
+use super::errors::OnChainError;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)]
@@ -67,9 +67,9 @@ impl<P: Patch> PC<P> {
         }
     }
 
-    fn read_bytes(&self, from_position: usize, byte_count: usize) -> Result<M256, RuntimeError> {
+    fn read_bytes(&self, from_position: usize, byte_count: usize) -> Result<M256, OnChainError> {
         if from_position > self.code.len() {
-            return Err(RuntimeError::OnChain(OnChainError::PCOverflow));
+            return Err(OnChainError::PCOverflow);
         }
         let position = from_position;
         let max = min(position.saturating_add(byte_count), self.code.len());
@@ -122,10 +122,10 @@ impl<P: Patch> PC<P> {
     }
 
     /// Peek the next instruction.
-    pub fn peek(&self) -> Result<Instruction, RuntimeError> {
+    pub fn peek(&self) -> Result<Instruction, OnChainError> {
         let position = self.position;
         if position >= self.code.len() {
-            return Err(OnChainError::PCOverflow.into());
+            return Err(OnChainError::PCOverflow);
         }
         let opcode: Opcode = self.code[position].into();
         Ok(match opcode {
@@ -207,19 +207,19 @@ impl<P: Patch> PC<P> {
                 if P::has_delegate_call() {
                     Instruction::DELEGATECALL
                 } else {
-                    return Err(OnChainError::InvalidOpcode.into());
+                    return Err(OnChainError::InvalidOpcode);
                 }
             },
 
             Opcode::INVALID => {
-                return Err(OnChainError::InvalidOpcode.into());
+                return Err(OnChainError::InvalidOpcode);
             },
             Opcode::SUICIDE => Instruction::SUICIDE,
         })
     }
 
     /// Read the next instruction and step the program counter.
-    pub fn read(&mut self) -> Result<Instruction, RuntimeError> {
+    pub fn read(&mut self) -> Result<Instruction, OnChainError> {
         let result = self.peek()?;
         let opcode: Opcode = self.code[self.position].into();
         match opcode {


### PR DESCRIPTION
1. PCIndexNotSupported error is removed. That will never happen, even in theory.
2. Patch::memory_limit now allows setting a customized memory limit. A contract exceeding this limit results in a not supported error. (So it doesn't need to take up all memory and then get killed by the OS.)