### PR TITLE
Add initial nonce support using AccountPatch

### DIFF
--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -319,7 +319,7 @@ fn test_all_previously_failed_frontier_blocks() {
     let numbers: Vec<usize> = serde_json::from_str(include_str!("../../res/frontier_numbers.json")).unwrap();
     let mut client = CachedGethRPCClient::from_value(cached);
     for n in numbers {
-        test_block::<_, FrontierPatch>(&mut client, n);
+        test_block::<_, MainnetFrontierPatch>(&mut client, n);
     }
 }
 
@@ -330,7 +330,7 @@ fn test_all_previously_failed_homestead_blocks() {
     let numbers: Vec<usize> = serde_json::from_str(include_str!("../../res/homestead_numbers.json")).unwrap();
     let mut client = CachedGethRPCClient::from_value(cached);
     for n in numbers {
-        test_block::<_, HomesteadPatch>(&mut client, n);
+        test_block::<_, MainnetHomesteadPatch>(&mut client, n);
     }
 }
 
@@ -341,6 +341,6 @@ fn test_all_previously_failed_eip150_blocks() {
     let numbers: Vec<usize> = serde_json::from_str(include_str!("../../res/eip150_numbers.json")).unwrap();
     let mut client = CachedGethRPCClient::from_value(cached);
     for n in numbers {
-        test_block::<_, EIP150Patch>(&mut client, n);
+        test_block::<_, MainnetEIP150Patch>(&mut client, n);
     }
 }

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -19,8 +19,8 @@ use block::TransactionAction;
 use bigint::{Gas, Address, U256, M256, H256};
 use hexutil::*;
 use sputnikvm::{HeaderParams, Context, SeqTransactionVM, ValidTransaction, VM, Log, Patch,
-                AccountCommitment, AccountChange, FrontierPatch, HomesteadPatch,
-                EIP150Patch, EIP160Patch};
+                AccountCommitment, AccountChange, MainnetFrontierPatch, MainnetHomesteadPatch,
+                MainnetEIP150Patch, MainnetEIP160Patch};
 use sputnikvm::errors::RequireError;
 use gethrpc::{GethRPCClient, NormalGethRPCClient, RecordGethRPCClient, CachedGethRPCClient, RPCCall, RPCBlock, RPCTransaction, RPCLog};
 
@@ -241,10 +241,10 @@ fn test_block<T: GethRPCClient, P: Patch>(client: &mut T, number: usize) {
 
 fn test_blocks_patch<T: GethRPCClient>(client: &mut T, number: &str, patch: Option<&str>) {
     match patch {
-        Some("frontier") => test_blocks::<_, FrontierPatch>(client, number),
-        Some("homestead") => test_blocks::<_, HomesteadPatch>(client, number),
-        Some("eip150") => test_blocks::<_, EIP150Patch>(client, number),
-        Some("eip160") => test_blocks::<_, EIP160Patch>(client, number),
+        Some("frontier") => test_blocks::<_, MainnetFrontierPatch>(client, number),
+        Some("homestead") => test_blocks::<_, MainnetHomesteadPatch>(client, number),
+        Some("eip150") => test_blocks::<_, MainnetEIP150Patch>(client, number),
+        Some("eip160") => test_blocks::<_, MainnetEIP160Patch>(client, number),
         _ => panic!("Unknown patch."),
     }
 }

--- a/src/eval/check.rs
+++ b/src/eval/check.rs
@@ -9,7 +9,7 @@ use eval::{State, ControlCheck};
 use super::util::check_range;
 
 #[allow(unused_variables)]
-pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M>, stipend_gas: Gas, after_gas: Gas) -> Result<(), OnChainError> {
+pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>, stipend_gas: Gas, after_gas: Gas) -> Result<(), OnChainError> {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE | Instruction::DELEGATECALL => {
             if P::err_on_call_with_more_gas() && after_gas < state.stack.peek(0).unwrap().into() {
@@ -22,7 +22,7 @@ pub fn extra_check_opcode<M: Memory + Default, P: Patch>(instruction: Instructio
     }
 }
 
-pub fn check_support<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Result<(), NotSupportedError> {
+pub fn check_support<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Result<(), NotSupportedError> {
     match instruction {
         Instruction::MSTORE => {
             state.memory.check_write(state.stack.peek(0).unwrap().into())?;
@@ -69,7 +69,7 @@ pub fn check_support<M: Memory + Default>(instruction: Instruction, state: &Stat
 #[allow(unused_variables)]
 /// Check whether `run_opcode` would fail without mutating any of the
 /// machine state.
-pub fn check_opcode<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Result<Option<ControlCheck>, EvalOnChainError> {
+pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Result<Option<ControlCheck>, EvalOnChainError> {
     match instruction {
         Instruction::STOP => Ok(None),
         Instruction::ADD => { state.stack.check_pop_push(2, 1)?; Ok(None) },

--- a/src/eval/cost.rs
+++ b/src/eval/cost.rs
@@ -32,7 +32,7 @@ const G_SHA3WORD: usize = 6;
 const G_COPY: usize = 3;
 const G_BLOCKHASH: usize = 20;
 
-fn sstore_cost<M: Memory + Default>(machine: &State<M>) -> Gas {
+fn sstore_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>) -> Gas {
     let index: U256 = machine.stack.peek(0).unwrap().into();
     let value = machine.stack.peek(1).unwrap();
     let address = machine.context.address;
@@ -44,11 +44,11 @@ fn sstore_cost<M: Memory + Default>(machine: &State<M>) -> Gas {
     }
 }
 
-fn call_cost<M: Memory + Default, P: Patch>(machine: &State<M>, instruction: &Instruction) -> Gas {
+fn call_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>, instruction: &Instruction) -> Gas {
     Gas::from(P::gas_call()) + xfer_cost(machine, instruction) + new_cost(machine, instruction)
 }
 
-fn xfer_cost<M: Memory + Default>(machine: &State<M>, instruction: &Instruction) -> Gas {
+fn xfer_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>, instruction: &Instruction) -> Gas {
     if instruction == &Instruction::CALL || instruction == &Instruction::CALLCODE {
         let val = machine.stack.peek(2).unwrap();
         if val != M256::zero() {
@@ -61,7 +61,7 @@ fn xfer_cost<M: Memory + Default>(machine: &State<M>, instruction: &Instruction)
     }
 }
 
-fn new_cost<M: Memory + Default>(machine: &State<M>, instruction: &Instruction) -> Gas {
+fn new_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>, instruction: &Instruction) -> Gas {
     let address: Address = machine.stack.peek(1).unwrap().into();
     if instruction == &Instruction::CALL && !machine.account_state.exists(address).unwrap() {
         Gas::from(G_NEWACCOUNT)
@@ -70,7 +70,7 @@ fn new_cost<M: Memory + Default>(machine: &State<M>, instruction: &Instruction) 
     }
 }
 
-fn suicide_cost<M: Memory + Default, P: Patch>(machine: &State<M>) -> Gas {
+fn suicide_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>) -> Gas {
     let address: Address = machine.stack.peek(0).unwrap().into();
     Gas::from(P::gas_suicide()) + if !machine.account_state.exists(address).unwrap() {
         Gas::from(P::gas_suicide_new_account())
@@ -105,7 +105,7 @@ pub fn memory_gas(a: Gas) -> Gas {
 
 /// Calculate the memory cost. This is the same as the active memory
 /// length in the Yellow Paper.
-pub fn memory_cost<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Gas {
+pub fn memory_cost<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Gas {
     let ref stack = state.stack;
 
     let current = state.memory_cost;
@@ -154,7 +154,7 @@ pub fn memory_cost<M: Memory + Default>(instruction: Instruction, state: &State<
 }
 
 /// Calculate the gas cost.
-pub fn gas_cost<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M>) -> Gas {
+pub fn gas_cost<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Gas {
     match instruction {
         Instruction::CALL => call_cost::<M, P>(state, &Instruction::CALL),
         Instruction::CALLCODE => call_cost::<M, P>(state, &Instruction::CALLCODE),
@@ -242,7 +242,7 @@ pub fn gas_cost<M: Memory + Default, P: Patch>(instruction: Instruction, state: 
 }
 
 /// Raise gas stipend for CALL and CALLCODE instruction.
-pub fn gas_stipend<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Gas {
+pub fn gas_stipend<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Gas {
     match instruction {
         Instruction::CALL | Instruction::CALLCODE => {
             let value = state.stack.peek(2).unwrap();
@@ -258,7 +258,7 @@ pub fn gas_stipend<M: Memory + Default>(instruction: Instruction, state: &State<
 }
 
 /// Calculate the refunded gas.
-pub fn gas_refund<M: Memory + Default>(instruction: Instruction, state: &State<M>) -> Gas {
+pub fn gas_refund<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Gas {
     match instruction {
         Instruction::SSTORE => {
             let index: U256 = state.stack.peek(0).unwrap().into();

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -92,7 +92,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
 
     /// Finalize a transaction. This should not be used when invoked
     /// by an opcode.
-    pub fn finalize(&mut self, real_used_gas: Gas, preclaimed_value: U256, fresh_account_state: &AccountState) -> Result<(), RequireError> {
+    pub fn finalize(&mut self, real_used_gas: Gas, preclaimed_value: U256, fresh_account_state: &AccountState<P::Account>) -> Result<(), RequireError> {
         self.state.account_state.require(self.state.context.address)?;
 
         match self.status() {

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -16,7 +16,7 @@ mod util;
 mod lifecycle;
 
 /// A VM state without PC.
-pub struct State<M> {
+pub struct State<M, P: Patch> {
     /// Memory of this runtime.
     pub memory: M,
     /// Stack of this runtime.
@@ -39,7 +39,7 @@ pub struct State<M> {
     pub refunded_gas: Gas,
 
     /// The current account commitment states.
-    pub account_state: AccountState,
+    pub account_state: AccountState<P::Account>,
     /// The current blockhash commitment states.
     pub blockhash_state: BlockhashState,
     /// Logs appended.
@@ -51,7 +51,7 @@ pub struct State<M> {
     pub depth: usize,
 }
 
-impl<M> State<M> {
+impl<M, P: Patch> State<M, P> {
     /// Memory gas, part of total used gas.
     pub fn memory_gas(&self) -> Gas {
         memory_gas(self.memory_cost)
@@ -70,7 +70,7 @@ impl<M> State<M> {
 
 /// A VM state with PC.
 pub struct Machine<M, P: Patch> {
-    state: State<M>,
+    state: State<M, P>,
     pc: PC<P>,
     status: MachineStatus,
 }
@@ -119,7 +119,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
 
     /// Create a new runtime with the given states.
     pub fn with_states(context: Context, block: HeaderParams,
-                       depth: usize, account_state: AccountState,
+                       depth: usize, account_state: AccountState<P::Account>,
                        blockhash_state: BlockhashState) -> Self {
         Machine {
             pc: PC::new(context.code.as_slice()),
@@ -329,7 +329,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Get the runtime state.
-    pub fn state(&self) -> &State<M> {
+    pub fn state(&self) -> &State<M, P> {
         &self.state
     }
 

--- a/src/eval/run/arithmetic.rs
+++ b/src/eval/run/arithmetic.rs
@@ -4,8 +4,9 @@ use bigint::{M256, U512};
 
 use ::Memory;
 use super::State;
+use patch::Patch;
 
-pub fn addmod<M: Memory + Default>(state: &mut State<M>) {
+pub fn addmod<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1: U512, op2: U512, op3: U512);
 
     if op3 == U512::zero() {
@@ -16,7 +17,7 @@ pub fn addmod<M: Memory + Default>(state: &mut State<M>) {
     }
 }
 
-pub fn mulmod<M: Memory + Default>(state: &mut State<M>) {
+pub fn mulmod<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1: U512, op2: U512, op3: U512);
 
     if op3 == U512::zero() {
@@ -28,7 +29,7 @@ pub fn mulmod<M: Memory + Default>(state: &mut State<M>) {
 }
 
 
-pub fn exp<M: Memory + Default>(state: &mut State<M>) {
+pub fn exp<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1, op2);
     let mut op1 = op1;
     let mut op2 = op2;
@@ -45,7 +46,7 @@ pub fn exp<M: Memory + Default>(state: &mut State<M>) {
     push!(state, r);
 }
 
-pub fn signextend<M: Memory + Default>(state: &mut State<M>) {
+pub fn signextend<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1, op2);
 
     if op1 > M256::from(32) {

--- a/src/eval/run/bitwise.rs
+++ b/src/eval/run/bitwise.rs
@@ -4,8 +4,9 @@ use bigint::M256;
 
 use ::Memory;
 use super::State;
+use patch::Patch;
 
-pub fn iszero<M: Memory + Default>(state: &mut State<M>) {
+pub fn iszero<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1);
 
     if op1 == M256::zero() {
@@ -15,12 +16,12 @@ pub fn iszero<M: Memory + Default>(state: &mut State<M>) {
     }
 }
 
-pub fn not<M: Memory + Default>(state: &mut State<M>) {
+pub fn not<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1);
     push!(state, !op1);
 }
 
-pub fn byte<M: Memory + Default>(state: &mut State<M>) {
+pub fn byte<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, op1, op2);
 
     let mut ret = M256::zero();

--- a/src/eval/run/environment.rs
+++ b/src/eval/run/environment.rs
@@ -2,8 +2,9 @@
 
 use ::Memory;
 use super::State;
+use patch::Patch;
 
-pub fn calldataload<M: Memory + Default>(state: &mut State<M>) {
+pub fn calldataload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index);
     let index: Option<usize> = if index > usize::max_value().into() {
         None

--- a/src/eval/run/flow.rs
+++ b/src/eval/run/flow.rs
@@ -3,30 +3,31 @@
 use ::Memory;
 use bigint::{U256, M256};
 use super::State;
+use patch::Patch;
 
-pub fn sload<M: Memory + Default>(state: &mut State<M>) {
+pub fn sload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256);
     let value = state.account_state.storage(state.context.address).unwrap().read(index).unwrap();
     push!(state, value);
 }
 
-pub fn sstore<M: Memory + Default>(state: &mut State<M>) {
+pub fn sstore<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256, value: M256);
     state.account_state.storage_mut(state.context.address).unwrap().write(index, value).unwrap();
 }
 
-pub fn mload<M: Memory + Default>(state: &mut State<M>) {
+pub fn mload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256);
     let value = state.memory.read(index);
     push!(state, value);
 }
 
-pub fn mstore<M: Memory + Default>(state: &mut State<M>) {
+pub fn mstore<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256, value: M256);
     state.memory.write(index, value).unwrap();
 }
 
-pub fn mstore8<M: Memory + Default>(state: &mut State<M>) {
+pub fn mstore8<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256, value: M256);
     state.memory.write_raw(index, (value.0.low_u32() & 0xFF) as u8).unwrap();
 }

--- a/src/eval/run/mod.rs
+++ b/src/eval/run/mod.rs
@@ -57,7 +57,7 @@ use super::util::{copy_from_memory, copy_into_memory};
 
 #[allow(unused_variables)]
 /// Run an instruction.
-pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state: &mut State<M>, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
+pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state: &mut State<M, P>, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
     match pc.0 {
         Instruction::STOP => { Some(Control::Stop) },
         Instruction::ADD => { op2!(state, add); None },

--- a/src/eval/run/system.rs
+++ b/src/eval/run/system.rs
@@ -9,7 +9,7 @@ use super::{Control, State};
 use std::cmp::min;
 use sha3::{Digest, Keccak256};
 
-pub fn suicide<M: Memory + Default>(state: &mut State<M>) {
+pub fn suicide<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, address: Address);
     let balance = state.account_state.balance(state.context.address).unwrap();
     if !state.removed.contains(&state.context.address) {
@@ -21,7 +21,7 @@ pub fn suicide<M: Memory + Default>(state: &mut State<M>) {
     state.account_state.decrease_balance(state.context.address, balance);
 }
 
-pub fn log<M: Memory + Default>(state: &mut State<M>, topic_len: usize) {
+pub fn log<M: Memory + Default, P: Patch>(state: &mut State<M, P>, topic_len: usize) {
     pop!(state, index: U256, len: U256);
     let data = copy_from_memory(&state.memory, index, len);
     let mut topics = Vec::new();
@@ -36,7 +36,7 @@ pub fn log<M: Memory + Default>(state: &mut State<M>, topic_len: usize) {
     });
 }
 
-pub fn sha3<M: Memory + Default>(state: &mut State<M>) {
+pub fn sha3<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, from: U256, len: U256);
     let data = copy_from_memory(&state.memory, from, len);
     let ret = Keccak256::digest(data.as_slice());
@@ -61,7 +61,7 @@ macro_rules! try_balance {
     }
 }
 
-pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M>, after_gas: Gas) -> Option<Control> {
+pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas: Gas) -> Option<Control> {
     let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
 
     pop!(state, value: U256);
@@ -80,7 +80,7 @@ pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M>, after_gas: Ga
         action: TransactionAction::Create,
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
-    let context = transaction.into_context(
+    let context = transaction.into_context::<P>(
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
 
@@ -88,7 +88,7 @@ pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M>, after_gas: Ga
     Some(Control::InvokeCreate(context))
 }
 
-pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M>, stipend_gas: Gas, after_gas: Gas, as_self: bool) -> Option<Control> {
+pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas: Gas, after_gas: Gas, as_self: bool) -> Option<Control> {
     let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
 
     pop!(state, gas: Gas, to: Address, value: U256);
@@ -109,7 +109,7 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M>, stipend_gas: Ga
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
 
-    let mut context = transaction.into_context(
+    let mut context = transaction.into_context::<P>(
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
     if as_self {
@@ -120,7 +120,7 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M>, stipend_gas: Ga
     Some(Control::InvokeCall(context, (out_start, out_len)))
 }
 
-pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M>, after_gas: Gas) -> Option<Control> {
+pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas: Gas) -> Option<Control> {
     let l64_after_gas = if P::call_create_l64_after_gas() { l64(after_gas) } else { after_gas };
 
     pop!(state, gas: Gas, to: Address);
@@ -140,7 +140,7 @@ pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M>, after_
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
 
-    let mut context = transaction.into_context(
+    let mut context = transaction.into_context::<P>(
         Gas::zero(), Some(state.context.origin), &mut state.account_state, true
     ).unwrap();
     context.value = U256::zero();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ impl<M: Memory + Default, P: Patch> ContextVM<M, P> {
 
     /// Create a new VM with the given account state and blockhash state.
     pub fn with_states(context: Context, block: HeaderParams,
-                       account_state: AccountState, blockhash_state: BlockhashState) -> Self {
+                       account_state: AccountState<P::Account>, blockhash_state: BlockhashState) -> Self {
         let mut machines = Vec::new();
         machines.push(Machine::with_states(context, block, 1, account_state, blockhash_state));
         ContextVM {
@@ -162,7 +162,7 @@ impl<M: Memory + Default, P: Patch> ContextVM<M, P> {
     }
 
     /// Returns the current state of the VM.
-    pub fn current_state(&self) -> &State<M> {
+    pub fn current_state(&self) -> &State<M, P> {
         self.current_machine().state()
     }
 

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -7,10 +7,26 @@ pub use self::precompiled::*;
 
 use std::ops::Deref;
 use std::str::FromStr;
-use bigint::{Address, Gas};
+use std::marker::PhantomData;
+use bigint::{Address, Gas, U256};
+
+/// Account patch for account related variables.
+pub trait AccountPatch {
+    /// Initial nonce for accounts.
+    fn initial_nonce() -> U256;
+}
+
+/// Mainnet account patch
+pub struct MainnetAccountPatch;
+impl AccountPatch for MainnetAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+}
 
 /// Represents different block range context.
 pub trait Patch {
+    /// Account patch
+    type Account: AccountPatch;
+
     /// Limit of the call stack.
     fn callstack_limit() -> usize;
     /// Gas paid for extcode.
@@ -66,8 +82,11 @@ lazy_static! {
 }
 
 /// Frontier patch.
-pub struct FrontierPatch;
-impl Patch for FrontierPatch {
+pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for FrontierPatch<A> {
+    type Account = A;
+
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -87,8 +106,11 @@ impl Patch for FrontierPatch {
 }
 
 /// Homestead patch.
-pub struct HomesteadPatch;
-impl Patch for HomesteadPatch {
+pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for HomesteadPatch<A> {
+    type Account = A;
+
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -110,6 +132,8 @@ impl Patch for HomesteadPatch {
 /// Patch sepcific for the `jsontests` crate.
 pub struct VMTestPatch;
 impl Patch for VMTestPatch {
+    type Account = MainnetAccountPatch;
+
     fn callstack_limit() -> usize { 2 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -129,8 +153,11 @@ impl Patch for VMTestPatch {
 }
 
 /// EIP150 patch.
-pub struct EIP150Patch;
-impl Patch for EIP150Patch {
+pub struct EIP150Patch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for EIP150Patch<A> {
+    type Account = A;
+
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(700usize) }
     fn gas_balance() -> Gas { Gas::from(400usize) }
@@ -150,8 +177,11 @@ impl Patch for EIP150Patch {
 }
 
 /// EIP160 patch.
-pub struct EIP160Patch;
-impl Patch for EIP160Patch {
+pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for EIP160Patch<A> {
+    type Account = A;
+
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(700usize) }
     fn gas_balance() -> Gas { Gas::from(400usize) }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -454,7 +454,7 @@ mod tests {
             input: Vec::new(),
             nonce: U256::zero(),
         };
-        let mut vm = SeqTransactionVM::<EIP160Patch>::new(transaction, HeaderParams {
+        let mut vm = SeqTransactionVM::<MainnetEIP160Patch>::new(transaction, HeaderParams {
             beneficiary: Address::default(),
             timestamp: 0,
             number: U256::zero(),

--- a/stateful/examples/parallel.rs
+++ b/stateful/examples/parallel.rs
@@ -9,7 +9,7 @@ extern crate sputnikvm_stateful;
 use hexutil::*;
 use block::TransactionAction;
 use bigint::{Address, U256, Gas};
-use sputnikvm::{AccountChange, HeaderParams, SeqTransactionVM, VM, Storage, EIP160Patch, ValidTransaction};
+use sputnikvm::{AccountChange, HeaderParams, SeqTransactionVM, VM, Storage, MainnetEIP160Patch, ValidTransaction};
 use trie::MemoryDatabase;
 use sputnikvm_stateful::{MemoryStateful, LiteralAccount};
 use std::thread;
@@ -47,7 +47,7 @@ pub fn parallel_execute(
         let stateful = stateful.clone();
 
         threads.push(thread::spawn(move || {
-            let vm: SeqTransactionVM<EIP160Patch> = stateful.call(
+            let vm: SeqTransactionVM<MainnetEIP160Patch> = stateful.call(
                 transaction, header, &[]);
             let accounts: Vec<AccountChange> = vm.accounts().map(|v| v.clone()).collect();
             (accounts, vm.used_addresses())
@@ -73,7 +73,7 @@ pub fn parallel_execute(
         let (accounts, used_addresses) = if is_modified(&modified_addresses, &accounts) {
             // Re-execute the transaction if conflict is detected.
             println!("Transaction index {}: conflict detected, re-execute.", index);
-            let vm: SeqTransactionVM<EIP160Patch> = stateful.call(
+            let vm: SeqTransactionVM<MainnetEIP160Patch> = stateful.call(
                 transactions[index].clone(), header.clone(), &[]);
             let accounts: Vec<AccountChange> = vm.accounts().map(|v| v.clone()).collect();
             (accounts, vm.used_addresses())


### PR DESCRIPTION
Using `AccountPatch::initial_nonce`.

Fix #278.