### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,10 @@ etcommon-block = { version = "0.3", optional = true }
 secp256k1-plus = { version = "0.5.7", optional = true }
 sha2 = { version = "0.6", optional = true }
 ripemd160 = { version = "0.6", optional = true }
-lazy_static = { version = "0.2", optional = true }
 
 [features]
 default = ["std"]
-std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-hexutil/std", "etcommon-block", "secp256k1-plus", "sha2", "ripemd160", "lazy_static"]
+std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-hexutil/std", "etcommon-block", "secp256k1-plus", "sha2", "ripemd160"]
 
 [workspace]
 members = [

--- a/nightly.nix
+++ b/nightly.nix
@@ -5,8 +5,8 @@ let pkgs = (
     rustOverlay = (pkgs_.fetchFromGitHub {
       owner = "mozilla";
       repo = "nixpkgs-mozilla";
-      rev = "e2a920faec5a9ebd6ff34abf072aacb4e0ed6f70";
-      sha256 = "1lq7zg388y4wrbl165wraji9dmlb8rkjaiam9bq28n3ynsp4b6fz";
+      rev = "6179dd876578ca2931f864627598ede16ba6cdef";
+      sha256 = "1lim10a674621zayz90nhwiynlakxry8fyz1x209g9bdm38zy3av";
     });
   in (nixpkgs {
     overlays = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,6 @@ extern crate ripemd160;
 extern crate sha2;
 #[cfg(feature = "std")]
 extern crate secp256k1;
-#[cfg(feature = "std")]
-#[macro_use]
-extern crate lazy_static;
 
 mod util;
 mod memory;

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -65,24 +65,24 @@ pub trait Patch {
     fn memory_limit() -> usize;
     /// Precompiled contracts at given address, with required code,
     /// and its definition.
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)];
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)];
 }
 
 #[cfg(feature = "std")]
 lazy_static! {
-    static ref ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, Box<Precompiled>); 4] = [
+    static ref ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
         (Address::from_str("0x0000000000000000000000000000000000000001").unwrap(),
          None,
-         Box::new(ECRECPrecompiled)),
+         &ECREC_PRECOMPILED),
         (Address::from_str("0x0000000000000000000000000000000000000002").unwrap(),
          None,
-         Box::new(SHA256Precompiled)),
+         &SHA256_PRECOMPILED),
         (Address::from_str("0x0000000000000000000000000000000000000003").unwrap(),
          None,
-         Box::new(RIP160Precompiled)),
+         &RIP160_PRECOMPILED),
         (Address::from_str("0x0000000000000000000000000000000000000004").unwrap(),
          None,
-         Box::new(IDPrecompiled)),
+         &ID_PRECOMPILED),
     ];
 }
 
@@ -109,7 +109,7 @@ impl<A: AccountPatch> Patch for FrontierPatch<A> {
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         ETC_PRECOMPILEDS.deref() }
 }
 
@@ -136,7 +136,7 @@ impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         ETC_PRECOMPILEDS.deref() }
 }
 
@@ -161,7 +161,7 @@ impl Patch for VMTestPatch {
     fn err_on_call_with_more_gas() -> bool { true }
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         ETC_PRECOMPILEDS.deref() }
 }
 
@@ -188,7 +188,7 @@ impl<A: AccountPatch> Patch for EIP150Patch<A> {
     fn err_on_call_with_more_gas() -> bool { false }
     fn call_create_l64_after_gas() -> bool { true }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         ETC_PRECOMPILEDS.deref() }
 }
 
@@ -215,11 +215,11 @@ impl<A: AccountPatch> Patch for EIP160Patch<A> {
     fn err_on_call_with_more_gas() -> bool { false }
     fn call_create_l64_after_gas() -> bool { true }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         ETC_PRECOMPILEDS.deref() }
 }
 
-static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, Box<Precompiled>); 0] = [];
+static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 0] = [];
 
 /// EIP160 patch.
 pub struct EmbeddedPatch<A: AccountPatch>(PhantomData<A>);
@@ -241,6 +241,6 @@ impl<A: AccountPatch> Patch for EmbeddedPatch<A> {
     fn err_on_call_with_more_gas() -> bool { false }
     fn call_create_l64_after_gas() -> bool { true }
     fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, Box<Precompiled>)] {
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
         &EMBEDDED_PRECOMPILEDS }
 }

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,18 +1,14 @@
 //! Patch of a VM, indicating different hard-fork of the Ethereum
 //! block range.
 
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-
 mod precompiled;
 
 pub use self::precompiled::*;
 
-#[cfg(feature = "std")] use std::ops::Deref;
-#[cfg(feature = "std")] use std::str::FromStr;
 #[cfg(feature = "std")] use std::marker::PhantomData;
 #[cfg(not(feature = "std"))] use core::marker::PhantomData;
 use bigint::{Address, Gas, U256};
+#[cfg(feature = "std")] use bigint::H160;
 
 /// Account patch for account related variables.
 pub trait AccountPatch {
@@ -69,22 +65,20 @@ pub trait Patch {
 }
 
 #[cfg(feature = "std")]
-lazy_static! {
-    static ref ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
-        (Address::from_str("0x0000000000000000000000000000000000000001").unwrap(),
-         None,
-         &ECREC_PRECOMPILED),
-        (Address::from_str("0x0000000000000000000000000000000000000002").unwrap(),
-         None,
-         &SHA256_PRECOMPILED),
-        (Address::from_str("0x0000000000000000000000000000000000000003").unwrap(),
-         None,
-         &RIP160_PRECOMPILED),
-        (Address::from_str("0x0000000000000000000000000000000000000004").unwrap(),
-         None,
-         &ID_PRECOMPILED),
-    ];
-}
+pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
 
 #[cfg(feature = "std")]
 /// Frontier patch.
@@ -110,7 +104,7 @@ impl<A: AccountPatch> Patch for FrontierPatch<A> {
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        ETC_PRECOMPILEDS.deref() }
+        &ETC_PRECOMPILEDS }
 }
 
 #[cfg(feature = "std")]
@@ -137,7 +131,7 @@ impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        ETC_PRECOMPILEDS.deref() }
+        &ETC_PRECOMPILEDS }
 }
 
 #[cfg(feature = "std")]
@@ -162,7 +156,7 @@ impl Patch for VMTestPatch {
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        ETC_PRECOMPILEDS.deref() }
+        &ETC_PRECOMPILEDS }
 }
 
 #[cfg(feature = "std")]
@@ -189,7 +183,7 @@ impl<A: AccountPatch> Patch for EIP150Patch<A> {
     fn call_create_l64_after_gas() -> bool { true }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        ETC_PRECOMPILEDS.deref() }
+        &ETC_PRECOMPILEDS }
 }
 
 #[cfg(feature = "std")]
@@ -216,10 +210,10 @@ impl<A: AccountPatch> Patch for EIP160Patch<A> {
     fn call_create_l64_after_gas() -> bool { true }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        ETC_PRECOMPILEDS.deref() }
+        &ETC_PRECOMPILEDS }
 }
 
-static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 0] = [];
+pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 0] = [];
 
 /// EIP160 patch.
 pub struct EmbeddedPatch<A: AccountPatch>(PhantomData<A>);

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -51,6 +51,7 @@ impl Precompiled for IDPrecompiled {
         data.into()
     }
 }
+pub static ID_PRECOMPILED: IDPrecompiled = IDPrecompiled;
 
 #[cfg(feature = "std")]
 /// RIP160 precompiled contract.
@@ -73,6 +74,7 @@ impl Precompiled for RIP160Precompiled {
         result.as_ref().into()
     }
 }
+pub static RIP160_PRECOMPILED: RIP160Precompiled = RIP160Precompiled;
 
 #[cfg(feature = "std")]
 /// SHA256 precompiled contract.
@@ -96,6 +98,7 @@ impl Precompiled for SHA256Precompiled {
         result.as_ref().into()
     }
 }
+pub static SHA256_PRECOMPILED: SHA256Precompiled = SHA256Precompiled;
 
 #[cfg(feature = "std")]
 /// ECREC precompiled contract.
@@ -122,6 +125,7 @@ impl Precompiled for ECRECPrecompiled {
         }
     }
 }
+pub static ECREC_PRECOMPILED: ECRECPrecompiled = ECRECPrecompiled;
 
 fn gas_div_ceil(a: Gas, b: Gas) -> Gas {
     if a % b == Gas::zero() {

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -51,6 +51,7 @@ impl Precompiled for IDPrecompiled {
         data.into()
     }
 }
+#[cfg(feature = "std")]
 pub static ID_PRECOMPILED: IDPrecompiled = IDPrecompiled;
 
 #[cfg(feature = "std")]
@@ -74,6 +75,7 @@ impl Precompiled for RIP160Precompiled {
         result.as_ref().into()
     }
 }
+#[cfg(feature = "std")]
 pub static RIP160_PRECOMPILED: RIP160Precompiled = RIP160Precompiled;
 
 #[cfg(feature = "std")]
@@ -98,6 +100,7 @@ impl Precompiled for SHA256Precompiled {
         result.as_ref().into()
     }
 }
+#[cfg(feature = "std")]
 pub static SHA256_PRECOMPILED: SHA256Precompiled = SHA256Precompiled;
 
 #[cfg(feature = "std")]
@@ -125,6 +128,7 @@ impl Precompiled for ECRECPrecompiled {
         }
     }
 }
+#[cfg(feature = "std")]
 pub static ECREC_PRECOMPILED: ECRECPrecompiled = ECRECPrecompiled;
 
 fn gas_div_ceil(a: Gas, b: Gas) -> Gas {


### PR DESCRIPTION
`lazy_static` does not work well in some occasions. This removes this dependency by using plain reference for precompiled trait object.