### PR TITLE
 Performance: move duplicate state information to VM Runtime 

### DIFF
--- a/src/eval/check.rs
+++ b/src/eval/check.rs
@@ -4,7 +4,7 @@ use bigint::{U256, M256, Gas};
 
 use ::{Memory, Instruction, Patch};
 use errors::{OnChainError, NotSupportedError, EvalOnChainError};
-use eval::{State, ControlCheck};
+use eval::{State, Runtime, ControlCheck};
 
 use super::util::check_range;
 
@@ -69,7 +69,7 @@ pub fn check_support<M: Memory + Default, P: Patch>(instruction: Instruction, st
 #[allow(unused_variables)]
 /// Check whether `run_opcode` would fail without mutating any of the
 /// machine state.
-pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>) -> Result<Option<ControlCheck>, EvalOnChainError> {
+pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, state: &State<M, P>, runtime: &Runtime) -> Result<Option<ControlCheck>, EvalOnChainError> {
     match instruction {
         Instruction::STOP => Ok(None),
         Instruction::ADD => { state.stack.check_pop_push(2, 1)?; Ok(None) },
@@ -139,10 +139,10 @@ pub fn check_opcode<M: Memory + Default, P: Patch>(instruction: Instruction, sta
 
         Instruction::BLOCKHASH => {
             state.stack.check_pop_push(1, 1)?;
-            let current_number = state.block.number;
+            let current_number = runtime.block.number;
             let number: U256 = state.stack.peek(0).unwrap().into();
             if !(number >= current_number || current_number - number > U256::from(256u64)) {
-                state.blockhash_state.get(number)?;
+                runtime.blockhash_state.get(number)?;
             }
             Ok(None)
         },

--- a/src/eval/run/mod.rs
+++ b/src/eval/run/mod.rs
@@ -53,12 +53,12 @@ use bigint::{M256, MI256, U256, Address, Gas};
 #[cfg(feature = "std")] use std::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor};
 #[cfg(not(feature = "std"))] use core::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor};
 use ::{Memory, Instruction, Patch};
-use super::{State, Control};
+use super::{State, Runtime, Control};
 use super::util::{copy_from_memory, copy_into_memory};
 
 #[allow(unused_variables)]
 /// Run an instruction.
-pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state: &mut State<M, P>, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
+pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state: &mut State<M, P>, runtime: &Runtime, stipend_gas: Gas, after_gas: Gas) -> Option<Control> {
     match pc.0 {
         Instruction::STOP => { Some(Control::Stop) },
         Instruction::ADD => { op2!(state, add); None },
@@ -120,18 +120,18 @@ pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state
                                       None },
 
         Instruction::BLOCKHASH => { pop!(state, number: U256);
-                                    let current_number = state.block.number;
+                                    let current_number = runtime.block.number;
                                     if !(number >= current_number || current_number - number > U256::from(256u64)) {
-                                        push!(state, M256::from(state.blockhash_state.get(number).unwrap()));
+                                        push!(state, M256::from(runtime.blockhash_state.get(number).unwrap()));
                                     } else {
                                         push!(state, M256::zero());
                                     }
                                     None },
-        Instruction::COINBASE => { push!(state, M256::from(state.block.beneficiary)); None },
-        Instruction::TIMESTAMP => { push!(state, M256::from(state.block.timestamp)); None },
-        Instruction::NUMBER => { push!(state, M256::from(state.block.number)); None },
-        Instruction::DIFFICULTY => { push!(state, M256::from(state.block.difficulty)); None },
-        Instruction::GASLIMIT => { push!(state, state.block.gas_limit.into()); None },
+        Instruction::COINBASE => { push!(state, M256::from(runtime.block.beneficiary)); None },
+        Instruction::TIMESTAMP => { push!(state, M256::from(runtime.block.timestamp)); None },
+        Instruction::NUMBER => { push!(state, M256::from(runtime.block.number)); None },
+        Instruction::DIFFICULTY => { push!(state, M256::from(runtime.block.difficulty)); None },
+        Instruction::GASLIMIT => { push!(state, runtime.block.gas_limit.into()); None },
 
         Instruction::POP => { state.stack.pop().unwrap(); None },
         Instruction::MLOAD => { flow::mload(state); None },

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -73,6 +73,13 @@ impl<P: Patch> PC<P> {
         }
     }
 
+    /// Create a new program counter at given position.
+    pub(crate) fn with_position(code: &[u8], position: usize) -> Self {
+        let mut pc = Self::new(code);
+        pc.position = position;
+        pc
+    }
+
     fn read_bytes(&self, from_position: usize, byte_count: usize) -> Result<M256, OnChainError> {
         if from_position > self.code.len() {
             return Err(OnChainError::PCOverflow);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -240,7 +240,7 @@ impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
                 TransactionVMState::Constructing { ref blockhash_state, .. } =>
                     blockhash_state.clone(),
                 TransactionVMState::Running { ref vm, .. } =>
-                    vm.machines[0].state().blockhash_state.clone(),
+                    vm.runtime.blockhash_state.clone(),
             },
         })
     }
@@ -345,7 +345,8 @@ impl<M: Memory + Default, P: Patch> VM for TransactionVM<M, P> {
                         }
 
                         if !*finalized {
-                            vm.machines[0].finalize(real_used_gas, preclaimed_value,
+                            vm.machines[0].finalize(vm.runtime.block.beneficiary,
+                                                    real_used_gas, preclaimed_value,
                                                     fresh_account_state)?;
                             *finalized = true;
                             return Ok(());


### PR DESCRIPTION
This creates a framework that allows us addressing #161 in the future.
