### PR TITLE
Wrap immutable fields into Rc to avoid copying

### DIFF
--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -7,6 +7,7 @@ use sputnikvm::{Machine, Log, Context,
 use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::rc::Rc;
 
 pub struct JSONBlock {
     codes: HashMap<Address, Vec<u8>>,
@@ -44,7 +45,7 @@ impl JSONBlock {
         AccountCommitment::Full {
             address: address,
             balance: balance,
-            code: code.into(),
+            code: Rc::new(code.into()),
             nonce: nonce
         }
     }
@@ -70,7 +71,7 @@ impl JSONBlock {
 
         AccountCommitment::Code {
             address: address,
-            code: code.clone(),
+            code: Rc::new(code.clone()),
         }
     }
 
@@ -252,8 +253,8 @@ pub fn create_context(v: &Value) -> Context {
     Context {
         address: address,
         caller: caller,
-        code: code,
-        data: data,
+        code: Rc::new(code),
+        data: Rc::new(data),
         gas_limit: gas,
         gas_price: gas_price,
         origin: origin,

--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -9,6 +9,7 @@ pub use self::blockchain::{JSONBlock, create_block, create_context};
 
 use serde_json::Value;
 use std::str::FromStr;
+use std::ops::Deref;
 use bigint::{Gas, M256, U256, H256, Address};
 use hexutil::*;
 use sputnikvm::errors::RequireError;
@@ -105,7 +106,7 @@ pub fn test_machine(v: &Value, machine: &SeqContextVM<VMTestPatch>, block: &JSON
                     return false;
                 }
             }
-            if transaction.gas_limit != gas_limit || transaction.value != value || if destination.is_some() { transaction.data != data } else { transaction.code != data } {
+            if transaction.gas_limit != gas_limit || transaction.value != value || if destination.is_some() { transaction.data.deref() != &data } else { transaction.code.deref() != &data } {
                 if debug {
                     print!("\n");
                     println!("Transaction mismatch. gas limit 0x{:x} =?= 0x{:x}, value 0x{:x} =?= 0x{:x}, data {:?} =?= {:?}", transaction.gas_limit, gas_limit, transaction.value, value, transaction.data, data);

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -13,6 +13,7 @@ use std::fs::File;
 use std::path::Path;
 use std::io::{BufReader};
 use std::str::FromStr;
+use std::rc::Rc;
 use std::collections::{HashMap, HashSet};
 
 use block::TransactionAction;
@@ -45,7 +46,7 @@ fn from_rpc_transaction(transaction: &RPCTransaction) -> ValidTransaction {
         value: U256::from_str(&transaction.value).unwrap(),
         gas_limit: Gas::from_str(&transaction.gas).unwrap(),
         gas_price: Gas::from_str(&transaction.gasPrice).unwrap(),
-        input: read_hex(&transaction.input).unwrap(),
+        input: Rc::new(read_hex(&transaction.input).unwrap()),
         nonce: U256::from_str(&transaction.nonce).unwrap(),
     }
 }
@@ -85,7 +86,7 @@ fn handle_fire<T: GethRPCClient, P: Patch>(client: &mut T, vm: &mut SeqTransacti
                         nonce: nonce,
                         address: address,
                         balance: balance,
-                        code: code,
+                        code: Rc::new(code),
                     }).unwrap();
                 }
             },
@@ -106,7 +107,7 @@ fn handle_fire<T: GethRPCClient, P: Patch>(client: &mut T, vm: &mut SeqTransacti
                                                      &last_block_number)).unwrap();
                 vm.commit_account(AccountCommitment::Code {
                     address: address,
-                    code: code,
+                    code: Rc::new(code),
                 }).unwrap();
             },
             Err(RequireError::Blockhash(number)) => {

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -3,6 +3,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::Vec;
 
+#[cfg(not(feature = "std"))] use alloc::rc::Rc;
+#[cfg(feature = "std")] use std::rc::Rc;
+
 use bigint::{U256, M256, Gas, Address};
 use errors::{RequireError, OnChainError};
 use commit::AccountState;
@@ -84,12 +87,12 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
             if !P::force_code_deposit() {
                 self.status = MachineStatus::ExitedErr(OnChainError::EmptyGas);
             } else {
-                self.state.account_state.code_deposit(self.state.context.address, &[]);
+                self.state.account_state.code_deposit(self.state.context.address, Rc::new(Vec::new()));
             }
         } else {
             self.state.used_gas = self.state.used_gas + deposit_cost;
             self.state.account_state.code_deposit(self.state.context.address,
-                                                  self.state.out.as_slice());
+                                                  self.state.out.clone());
         }
     }
 

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -3,6 +3,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::Vec;
 
+#[cfg(not(feature = "std"))] use alloc::rc::Rc;
+#[cfg(feature = "std")] use std::rc::Rc;
+
 use bigint::{M256, U256, Gas, Address};
 use super::commit::{AccountState, BlockhashState};
 use super::errors::{RequireError, RuntimeError, CommitError, EvalOnChainError,
@@ -30,7 +33,7 @@ pub struct State<M, P: Patch> {
     pub context: Context,
 
     /// The current out value.
-    pub out: Vec<u8>,
+    pub out: Rc<Vec<u8>>,
 
     /// The current memory cost. Note that this is different from
     /// memory gas.
@@ -150,7 +153,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
                 memory: M::default(),
                 stack: Stack::default(),
 
-                out: Vec::new(),
+                out: Rc::new(Vec::new()),
 
                 memory_cost: Gas::zero(),
                 used_gas: Gas::zero(),
@@ -180,7 +183,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
                 memory: M::default(),
                 stack: Stack::default(),
 
-                out: Vec::new(),
+                out: Rc::new(Vec::new()),
 
                 memory_cost: Gas::zero(),
                 used_gas: Gas::zero(),

--- a/src/eval/run/system.rs
+++ b/src/eval/run/system.rs
@@ -3,6 +3,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::Vec;
 
+#[cfg(not(feature = "std"))] use alloc::rc::Rc;
+#[cfg(feature = "std")] use std::rc::Rc;
+
 use bigint::{U256, M256, H256, Address, Gas};
 use ::{Memory, Log, ValidTransaction, Patch};
 use eval::util::{l64, copy_from_memory};
@@ -75,7 +78,7 @@ pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas:
     try_callstack_limit!(state, P);
     try_balance!(state, value, Gas::zero());
 
-    let init = copy_from_memory(&state.memory, init_start, init_len);
+    let init = Rc::new(copy_from_memory(&state.memory, init_start, init_len));
     let transaction = ValidTransaction {
         caller: Some(state.context.address),
         gas_price: state.context.gas_price,
@@ -103,7 +106,7 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas:
     try_callstack_limit!(state, P);
     try_balance!(state, value, gas_limit);
 
-    let input = copy_from_memory(&state.memory, in_start, in_len);
+    let input = Rc::new(copy_from_memory(&state.memory, in_start, in_len));
     let transaction = ValidTransaction {
         caller: Some(state.context.address),
         gas_price: state.context.gas_price,
@@ -134,7 +137,7 @@ pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, aft
 
     try_callstack_limit!(state, P);
 
-    let input = copy_from_memory(&state.memory, in_start, in_len);
+    let input = Rc::new(copy_from_memory(&state.memory, in_start, in_len));
     let transaction = ValidTransaction {
         caller: Some(state.context.caller),
         gas_price: state.context.gas_price,

--- a/src/params.rs
+++ b/src/params.rs
@@ -3,6 +3,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::Vec;
 
+#[cfg(not(feature = "std"))] use alloc::rc::Rc;
+#[cfg(feature = "std")] use std::rc::Rc;
+
 use bigint::{U256, Address, Gas};
 #[cfg(feature = "std")]
 use block::Header;
@@ -43,9 +46,9 @@ pub struct Context {
     /// Caller of the runtime.
     pub caller: Address,
     /// Code to be executed.
-    pub code: Vec<u8>,
+    pub code: Rc<Vec<u8>>,
     /// Data associated with this execution.
-    pub data: Vec<u8>,
+    pub data: Rc<Vec<u8>>,
     /// Gas limit.
     pub gas_limit: Gas,
     /// Gas price.

--- a/stateful/src/lib.rs
+++ b/stateful/src/lib.rs
@@ -19,6 +19,8 @@ use trie::{FixedSecureTrie, DatabaseGuard, MemoryDatabase, Database, DatabaseOwn
 use block::{Account, Transaction};
 use std::collections::HashMap;
 use std::cmp::min;
+use std::rc::Rc;
+use std::ops::Deref;
 
 pub struct LiteralAccount {
     pub nonce: U256,
@@ -101,7 +103,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
                                 nonce: account.nonce,
                                 address: address,
                                 balance: account.balance,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {
@@ -122,7 +124,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
 
                             vm.commit_account(AccountCommitment::Code {
                                 address: address,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {
@@ -185,7 +187,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
                                 nonce: account.nonce,
                                 address: address,
                                 balance: account.balance,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {
@@ -206,7 +208,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
 
                             vm.commit_account(AccountCommitment::Code {
                                 address: address,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {
@@ -347,7 +349,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
                         }
 
                         let code_hash = H256::from(Keccak256::digest(&code).as_slice());
-                        code_hashes.set(code_hash, code);
+                        code_hashes.set(code_hash, code.deref().clone());
 
                         let account = Account {
                             nonce: nonce,
@@ -403,7 +405,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
                                 nonce: account.nonce,
                                 address: address,
                                 balance: account.balance,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {
@@ -424,7 +426,7 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
 
                             account_state.commit(AccountCommitment::Code {
                                 address: address,
-                                code: code,
+                                code: Rc::new(code),
                             }).unwrap();
                         },
                         None => {

--- a/stateful/tests/genesis.rs
+++ b/stateful/tests/genesis.rs
@@ -20,6 +20,7 @@ use block::TransactionAction;
 use trie::{Database, MemoryDatabase};
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::rc::Rc;
 use rand::Rng;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -69,6 +70,7 @@ fn morden_state_root() {
 
         let address = Address::from_str(key).unwrap();
         let balance = U256::from_dec_str(&value.balance).unwrap();
+        let empty_input = Rc::new(Vec::new());
 
         let vm: SeqTransactionVM<EIP160Patch<MordenAccountPatch>> = stateful.execute(ValidTransaction {
             caller: None,
@@ -76,7 +78,7 @@ fn morden_state_root() {
             gas_limit: Gas::from(100000u64),
             action: TransactionAction::Call(address),
             value: balance,
-            input: Vec::new(),
+            input: empty_input.clone(),
             nonce: U256::zero(),
         }, HeaderParams {
             beneficiary: Address::default(),
@@ -102,6 +104,7 @@ fn genesis_state_root() {
 
     let mut accounts: Vec<(&String, &JSONAccount)> = GENESIS_ACCOUNTS.iter().collect();
     rng.shuffle(&mut accounts);
+    let empty_input = Rc::new(Vec::new());
 
     for (key, value) in accounts {
         let address = Address::from_str(key).unwrap();
@@ -113,7 +116,7 @@ fn genesis_state_root() {
             gas_limit: Gas::from(100000u64),
             action: TransactionAction::Call(address),
             value: balance,
-            input: Vec::new(),
+            input: empty_input.clone(),
             nonce: U256::zero(),
         }, HeaderParams {
             beneficiary: Address::default(),


### PR DESCRIPTION
Fix #161.

Wrapping field in Rc makes it so that only a pointer is needed to be
copied for every callstack push.

* Account code: can only be created or deleted.
* Context code: same as account code.
* Context data: cannot be changed during VM execution.
* Out: can only be set by RETURN, and is not changable individually
  for its indexes.