### PR TITLE
Add back classic network patches for `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ name = "sputnikvm"
 
 [dependencies]
 sha3 = "0.6"
+sha2 = "0.6"
+ripemd160 = "0.6"
 digest = "0.6"
 etcommon-block-core = { version = "0.1", default-features = false }
 etcommon-rlp = { version = "0.2", default-features = false }
@@ -20,12 +22,10 @@ etcommon-hexutil = { version = "0.2", default-features = false }
 
 etcommon-block = { version = "0.3", optional = true }
 secp256k1-plus = { version = "0.5.7", optional = true }
-sha2 = { version = "0.6", optional = true }
-ripemd160 = { version = "0.6", optional = true }
 
 [features]
 default = ["std"]
-std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-hexutil/std", "etcommon-block", "secp256k1-plus", "sha2", "ripemd160"]
+std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-hexutil/std", "etcommon-block", "secp256k1-plus"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.7.8"
+version = "0.8.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,6 +61,8 @@ pub enum NotSupportedError {
     /// The memory index is too large for the implementation of the VM to
     /// handle.
     MemoryIndexNotSupported,
+    /// A particular precompiled contract is not supported.
+    PrecompiledNotSupported,
 }
 
 impl From<NotSupportedError> for RuntimeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,12 @@ extern crate bigint;
 extern crate hexutil;
 extern crate block_core;
 extern crate sha3;
+extern crate ripemd160;
+extern crate sha2;
 extern crate digest;
 
 #[cfg(feature = "std")]
 extern crate block;
-#[cfg(feature = "std")]
-extern crate ripemd160;
-#[cfg(feature = "std")]
-extern crate sha2;
 #[cfg(feature = "std")]
 extern crate secp256k1;
 

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -7,8 +7,7 @@ pub use self::precompiled::*;
 
 #[cfg(feature = "std")] use std::marker::PhantomData;
 #[cfg(not(feature = "std"))] use core::marker::PhantomData;
-use bigint::{Address, Gas, U256};
-#[cfg(feature = "std")] use bigint::H160;
+use bigint::{Address, Gas, U256, H160};
 
 /// Account patch for account related variables.
 pub trait AccountPatch {
@@ -64,7 +63,6 @@ pub trait Patch {
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)];
 }
 
-#[cfg(feature = "std")]
 pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
@@ -80,12 +78,9 @@ pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompi
      &ID_PRECOMPILED),
 ];
 
-#[cfg(feature = "std")]
 /// Frontier patch.
 pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
-#[cfg(feature = "std")]
 pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
-#[cfg(feature = "std")]
 impl<A: AccountPatch> Patch for FrontierPatch<A> {
     type Account = A;
 
@@ -107,12 +102,9 @@ impl<A: AccountPatch> Patch for FrontierPatch<A> {
         &ETC_PRECOMPILEDS }
 }
 
-#[cfg(feature = "std")]
 /// Homestead patch.
 pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
-#[cfg(feature = "std")]
 pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
-#[cfg(feature = "std")]
 impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     type Account = A;
 
@@ -134,10 +126,8 @@ impl<A: AccountPatch> Patch for HomesteadPatch<A> {
         &ETC_PRECOMPILEDS }
 }
 
-#[cfg(feature = "std")]
 /// Patch sepcific for the `jsontests` crate.
 pub struct VMTestPatch;
-#[cfg(feature = "std")]
 impl Patch for VMTestPatch {
     type Account = MainnetAccountPatch;
 
@@ -159,12 +149,9 @@ impl Patch for VMTestPatch {
         &ETC_PRECOMPILEDS }
 }
 
-#[cfg(feature = "std")]
 /// EIP150 patch.
 pub struct EIP150Patch<A: AccountPatch>(PhantomData<A>);
-#[cfg(feature = "std")]
 pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
-#[cfg(feature = "std")]
 impl<A: AccountPatch> Patch for EIP150Patch<A> {
     type Account = A;
 
@@ -186,12 +173,9 @@ impl<A: AccountPatch> Patch for EIP150Patch<A> {
         &ETC_PRECOMPILEDS }
 }
 
-#[cfg(feature = "std")]
 /// EIP160 patch.
 pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
-#[cfg(feature = "std")]
 pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
-#[cfg(feature = "std")]
 impl<A: AccountPatch> Patch for EIP160Patch<A> {
     type Account = A;
 
@@ -215,7 +199,7 @@ impl<A: AccountPatch> Patch for EIP160Patch<A> {
 
 pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 0] = [];
 
-/// EIP160 patch.
+/// Embedded patch.
 pub struct EmbeddedPatch<A: AccountPatch>(PhantomData<A>);
 pub type MainnetEmbeddedPatch = EmbeddedPatch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for EmbeddedPatch<A> {

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -8,16 +8,13 @@ use bigint::Gas;
 #[cfg(feature = "std")] use std::cmp::min;
 
 use errors::{RuntimeError, OnChainError};
-#[cfg(feature = "std")]
 use sha2::Sha256;
-#[cfg(feature = "std")]
-use sha3::Keccak256;
-#[cfg(feature = "std")]
+#[cfg(feature = "std")] use sha3::Keccak256;
 use ripemd160::Ripemd160;
+use digest::{Digest, FixedOutput};
+
 #[cfg(feature = "std")]
 use secp256k1::{SECP256K1, RecoverableSignature, Message, RecoveryId, Error};
-#[cfg(feature = "std")]
-use digest::{Digest, FixedOutput};
 
 /// Represent a precompiled contract.
 pub trait Precompiled: Sync {
@@ -40,10 +37,8 @@ pub trait Precompiled: Sync {
     }
 }
 
-#[cfg(feature = "std")]
 /// ID precompiled contract.
 pub struct IDPrecompiled;
-#[cfg(feature = "std")]
 impl Precompiled for IDPrecompiled {
     fn gas(&self, data: &[u8]) -> Gas {
         Gas::from(15u64) +
@@ -54,13 +49,10 @@ impl Precompiled for IDPrecompiled {
         Rc::new(data.into())
     }
 }
-#[cfg(feature = "std")]
 pub static ID_PRECOMPILED: IDPrecompiled = IDPrecompiled;
 
-#[cfg(feature = "std")]
 /// RIP160 precompiled contract.
 pub struct RIP160Precompiled;
-#[cfg(feature = "std")]
 impl Precompiled for RIP160Precompiled {
     fn gas(&self, data: &[u8]) -> Gas {
         Gas::from(600u64) +
@@ -78,13 +70,10 @@ impl Precompiled for RIP160Precompiled {
         Rc::new(result.as_ref().into())
     }
 }
-#[cfg(feature = "std")]
 pub static RIP160_PRECOMPILED: RIP160Precompiled = RIP160Precompiled;
 
-#[cfg(feature = "std")]
 /// SHA256 precompiled contract.
 pub struct SHA256Precompiled;
-#[cfg(feature = "std")]
 impl Precompiled for SHA256Precompiled {
     fn gas(&self, data: &[u8]) -> Gas {
         Gas::from(60u64) +
@@ -103,10 +92,8 @@ impl Precompiled for SHA256Precompiled {
         Rc::new(result.as_ref().into())
     }
 }
-#[cfg(feature = "std")]
 pub static SHA256_PRECOMPILED: SHA256Precompiled = SHA256Precompiled;
 
-#[cfg(feature = "std")]
 /// ECREC precompiled contract.
 pub struct ECRECPrecompiled;
 #[cfg(feature = "std")]
@@ -131,7 +118,14 @@ impl Precompiled for ECRECPrecompiled {
         }
     }
 }
-#[cfg(feature = "std")]
+#[cfg(not(feature = "std"))]
+impl Precompiled for ECRECPrecompiled {
+    fn gas_and_step(&self, _: &[u8], _: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
+        use errors::NotSupportedError;
+
+        Err(RuntimeError::NotSupported(NotSupportedError::PrecompiledNotSupported))
+    }
+}
 pub static ECREC_PRECOMPILED: ECRECPrecompiled = ECRECPrecompiled;
 
 fn gas_div_ceil(a: Gas, b: Gas) -> Gas {

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-stateful"
-version = "0.7.5"
+version = "0.8.0"
 license = "Apache-2.0"
 description = "Stateful SputnikVM wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -6,7 +6,7 @@ description = "Stateful SputnikVM wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]
 
 [dependencies]
-sputnikvm = { version = "0.7", path = '..' }
+sputnikvm = { version = "0.8", path = '..' }
 etcommon-bigint = "0.2"
 etcommon-trie = "0.3"
 etcommon-block = "0.3"


### PR DESCRIPTION
Originally they're disabled in `no_std` due to precompiled contracts. Support for `SHA2`, `RIP160` and `ID` precompiled contracts is now working for `no_std`. If a contract tries to invoke the `ECREC` precompiled contract, however, the VM would return a special error `PrecompiledNotSupported`.