### PR TITLE
Add libsecp256k1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ os:
 script:
   - cargo build --release --all --verbose
   - cargo test --release --all --verbose
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features; fi
+  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then cargo build --no-default-features --features rust-secp256k1; fi
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ etcommon-bigint = { version = "0.2", default-features = false, features = ["rlp"
 
 etcommon-block = { version = "0.3", optional = true }
 secp256k1-plus = { version = "0.5.7", optional = true }
+libsecp256k1 = { version = "0.1", optional = true }
 
 [dev-dependencies]
 etcommon-hexutil = "0.2"
 
 [features]
-default = ["std"]
-std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-block", "secp256k1-plus"]
+default = ["std", "c-secp256k1"]
+c-secp256k1 = ["secp256k1-plus"]
+rust-secp256k1 = ["libsecp256k1"]
+std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-block"]
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,14 @@ extern crate ripemd160;
 extern crate sha2;
 extern crate digest;
 
+#[cfg(feature = "c-secp256k1")]
+extern crate secp256k1;
+
+#[cfg(feature = "rust-secp256k1")]
+extern crate secp256k1;
+
 #[cfg(feature = "std")]
 extern crate block;
-#[cfg(feature = "std")]
-extern crate secp256k1;
 
 mod util;
 mod memory;

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -5,16 +5,20 @@ use alloc::Vec;
 #[cfg(feature = "std")] use std::rc::Rc;
 
 use bigint::Gas;
-#[cfg(feature = "std")] use std::cmp::min;
+#[cfg(all(feature = "std", any(feature = "rust-secp256k1", feature = "c-secp256k1")))] use std::cmp::min;
+#[cfg(all(not(feature = "std"), any(feature = "rust-secp256k1", feature = "c-secp256k1")))] use core::cmp::min;
 
 use errors::{RuntimeError, OnChainError};
 use sha2::Sha256;
-#[cfg(feature = "std")] use sha3::Keccak256;
+#[cfg(any(feature = "rust-secp256k1", feature = "c-secp256k1"))]
+use sha3::Keccak256;
 use ripemd160::Ripemd160;
 use digest::{Digest, FixedOutput};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "c-secp256k1")]
 use secp256k1::{SECP256K1, RecoverableSignature, Message, RecoveryId, Error};
+#[cfg(feature = "rust-secp256k1")]
+use secp256k1::{recover, Message, RecoveryId, Signature, Error};
 
 /// Represent a precompiled contract.
 pub trait Precompiled: Sync {
@@ -96,7 +100,7 @@ pub static SHA256_PRECOMPILED: SHA256Precompiled = SHA256Precompiled;
 
 /// ECREC precompiled contract.
 pub struct ECRECPrecompiled;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "c-secp256k1", feature = "rust-secp256k1"))]
 impl Precompiled for ECRECPrecompiled {
     fn gas(&self, _: &[u8]) -> Gas {
         Gas::from(3000u64)
@@ -118,7 +122,7 @@ impl Precompiled for ECRECPrecompiled {
         }
     }
 }
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "c-secp256k1"), not(feature = "rust-secp256k1")))]
 impl Precompiled for ECRECPrecompiled {
     fn gas_and_step(&self, _: &[u8], _: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
         use errors::NotSupportedError;
@@ -136,7 +140,7 @@ fn gas_div_ceil(a: Gas, b: Gas) -> Gas {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "c-secp256k1")]
 fn kececrec(data: &[u8]) -> Result<[u8; 32], Error> {
     let message = Message::from_slice(&data[0..32])?;
     let recid_raw = match data[63] {
@@ -147,6 +151,36 @@ fn kececrec(data: &[u8]) -> Result<[u8; 32], Error> {
     let sig = RecoverableSignature::from_compact(&SECP256K1, &data[64..128], recid)?;
     let recovered = SECP256K1.recover(&message, &sig)?;
     let key = recovered.serialize_vec(&SECP256K1, false);
+
+    let ret_generic = Keccak256::digest(&key[1..65]);
+    let mut ret = [0u8; 32];
+
+    for i in 0..32 {
+        ret[i] = ret_generic[i];
+    }
+
+    Ok(ret)
+}
+
+#[cfg(feature = "rust-secp256k1")]
+fn kececrec(data: &[u8]) -> Result<[u8; 32], Error> {
+    let mut message_raw = [0u8; 32];
+    for i in 0..32 {
+        message_raw[i] = data[i];
+    }
+    let message = Message::parse(&message_raw);
+    let recid_raw = match data[63] {
+        27 | 28 if data[32..63] == [0; 31] => data[63] - 27,
+        _ => return Err(Error::InvalidRecoveryId),
+    };
+    let recid = RecoveryId::parse(recid_raw)?;
+    let mut sig_raw = [0u8; 64];
+    for i in 0..64 {
+        sig_raw[i] = data[64 + i];
+    }
+    let sig = Signature::parse(&sig_raw);
+    let recovered = recover(&message, &sig, &recid)?;
+    let key = recovered.serialize();
 
     let ret_generic = Keccak256::digest(&key[1..65]);
     let mut ret = [0u8; 32];


### PR DESCRIPTION
libsecp256k1 is a pure Rust implementation of the secp256k1 curve with
`no_std` support, thus allowing kececrec precompiled contract to be
run on embedded device or WebAssembly.