### PR TITLE
Minor interface fixes for dependency and used_gas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.8.3"
+version = "0.8.4"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.8.1"
+version = "0.8.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
@@ -27,7 +27,7 @@ libsecp256k1 = { version = "0.1", optional = true }
 etcommon-hexutil = "0.2"
 
 [features]
-default = ["std", "c-secp256k1"]
+default = ["std", "rust-secp256k1"]
 c-secp256k1 = ["secp256k1-plus"]
 rust-secp256k1 = ["libsecp256k1"]
 std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-block"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.8.4"
+version = "0.9.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.8.2"
+version = "0.8.3"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
@@ -19,7 +19,7 @@ etcommon-block-core = { version = "0.1", default-features = false }
 etcommon-rlp = { version = "0.2", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false, features = ["rlp"] }
 
-etcommon-block = { version = "0.3", optional = true }
+etcommon-block = { version = "0.3", default-features = false, optional = true }
 secp256k1-plus = { version = "0.5.7", optional = true }
 libsecp256k1 = { version = "0.1", optional = true }
 
@@ -27,9 +27,9 @@ libsecp256k1 = { version = "0.1", optional = true }
 etcommon-hexutil = "0.2"
 
 [features]
-default = ["std", "rust-secp256k1"]
-c-secp256k1 = ["secp256k1-plus"]
-rust-secp256k1 = ["libsecp256k1"]
+default = ["std", "c-secp256k1"]
+c-secp256k1 = ["secp256k1-plus", "etcommon-block/c-secp256k1"]
+rust-secp256k1 = ["libsecp256k1", "etcommon-block/rust-secp256k1"]
 std = ["etcommon-block-core/std", "etcommon-rlp/std", "etcommon-bigint/std", "etcommon-block"]
 
 [workspace]

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -163,7 +163,7 @@ fn test_block<T: GethRPCClient, P: Patch>(client: &mut T, number: usize) {
 
         handle_fire(client, &mut vm, last_id);
 
-        assert!(Gas::from_str(&receipt.gasUsed).unwrap() == vm.real_used_gas());
+        assert!(Gas::from_str(&receipt.gasUsed).unwrap() == vm.used_gas());
         assert!(receipt.logs.len() == vm.logs().len());
         for i in 0..receipt.logs.len() {
             assert!(from_rpc_log(&receipt.logs[i]) == vm.logs()[i]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use self::commit::{AccountCommitment, AccountChange, AccountState, Blockhash
 pub use self::transaction::{ValidTransaction, TransactionVM};
 pub use self::errors::{OnChainError, NotSupportedError, RequireError, CommitError, PreExecutionError};
 pub use self::util::opcode::Opcode;
+pub use block_core::TransactionAction;
 
 #[cfg(not(feature = "std"))]
 use alloc::Vec;

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-stateful"
-version = "0.8.0"
+version = "0.9.0"
 license = "Apache-2.0"
 description = "Stateful SputnikVM wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-stateful"
-version = "0.9.0"
+version = "0.9.1"
 license = "Apache-2.0"
 description = "Stateful SputnikVM wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -6,7 +6,7 @@ description = "Stateful SputnikVM wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]
 
 [dependencies]
-sputnikvm = { version = "0.8", path = '..' }
+sputnikvm = { version = "0.9", path = '..' }
 etcommon-bigint = "0.2"
 etcommon-trie = "0.3"
 etcommon-block = "0.3"


### PR DESCRIPTION
* `real_used_gas` renamed to `used_gas`, and added to the VM trait. This allows using trait object for pointer referencing and retrieving in sputnikvm-go and other FFI implementations. This is a breaking change so we released another minor version v0.9.
* Fix a recursive dependency bug: etcommon-block would still require the c version of secp256k1 even when sputnikvm's rust-secp256k1 feature is enabled.
* Exported TransactionAction in sputnikvm namespace for convenience.