### PR TITLE
Storage::len convenience function and AccountChange::Nonexist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.9.0"
+version = "0.9.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -103,6 +103,12 @@ impl JSONBlock {
                 self.storages.insert(address, storage.into());
                 self.set_account_nonce(address, nonce);
             },
+            AccountChange::Nonexist(address) => {
+                self.set_balance(address, U256::zero());
+                self.set_account_code(address, &[]);
+                self.storages.insert(address, HashMap::new());
+                self.set_account_nonce(address, U256::zero());
+            },
             AccountChange::IncreaseBalance(address, topup) => {
                 let balance = self.balance(address);
                 self.set_balance(address, balance + topup);

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -235,6 +235,13 @@ fn test_block<T: GethRPCClient, P: Patch>(client: &mut T, number: usize) {
                                 U256::from_str(&cur_balance).unwrap());
                     }
                 },
+                &AccountChange::Nonexist(address) => {
+                    if !is_miner_or_uncle(client, address, &block) {
+                        let expected_balance = client.get_balance(&format!("0x{:x}", address),
+                                                                  &cur_number);
+                        assert!(U256::from_str(&expected_balance).unwrap() == U256::zero());
+                    }
+                },
             }
         }
     }

--- a/shell.nix
+++ b/shell.nix
@@ -5,8 +5,8 @@ let pkgs = (
     rustOverlay = (pkgs_.fetchFromGitHub {
       owner = "mozilla";
       repo = "nixpkgs-mozilla";
-      rev = "e2a920faec5a9ebd6ff34abf072aacb4e0ed6f70";
-      sha256 = "1lq7zg388y4wrbl165wraji9dmlb8rkjaiam9bq28n3ynsp4b6fz";
+      rev = "6179dd876578ca2931f864627598ede16ba6cdef";
+      sha256 = "1lim10a674621zayz90nhwiynlakxry8fyz1x209g9bdm38zy3av";
     });
   in (nixpkgs {
     overlays = [

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -119,7 +119,8 @@ pub enum AccountCommitment {
         /// Value at the given account storage index.
         value: M256,
     },
-    /// Indicate that an account does not exist.
+    /// Indicate that an account does not exist, or is a suicided
+    /// account.
     Nonexist(Address),
 }
 

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -437,29 +437,21 @@ impl<A: AccountPatch> AccountState<A> {
     /// Find code by its address in this account state. If the search
     /// failed, returns a `RequireError`.
     pub fn code(&self, address: Address) -> Result<Rc<Vec<u8>>, RequireError> {
-        if self.codes.contains_key(&address) {
-            return Ok(self.codes.get(&address).unwrap().clone());
-        }
-
         if self.accounts.contains_key(&address) {
             match self.accounts.get(&address).unwrap() {
-                &AccountChange::Full {
-                    ref code,
-                    ..
-                } => return Ok(code.clone()),
-                &AccountChange::Create {
-                    ref code,
-                    ..
-                } => return Ok(code.clone()),
-                &AccountChange::Nonexist(_) => {
-                    return Ok(Rc::new(Vec::new()));
-                },
-                &AccountChange::IncreaseBalance(address, _) => return Err(RequireError::Account(address)),
-                &AccountChange::DecreaseBalance(address, _) => return Err(RequireError::Account(address)),
+                &AccountChange::Full { ref code, .. } => return Ok(code.clone()),
+                &AccountChange::Create { ref code, .. } => return Ok(code.clone()),
+                &AccountChange::Nonexist(_) => return Ok(Rc::new(Vec::new())),
+                &AccountChange::IncreaseBalance(_, _) => (),
+                &AccountChange::DecreaseBalance(_, _) => (),
             }
         }
 
-        return Err(RequireError::AccountCode(address));
+        if self.codes.contains_key(&address) {
+            return Ok(self.codes.get(&address).unwrap().clone());
+        } else {
+            return Err(RequireError::AccountCode(address));
+        }
     }
 
     /// Find nonce by its address in this account state. If the search

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -371,6 +371,9 @@ impl<A: AccountPatch> AccountState<A> {
                                 code: Rc::new(Vec::new())
                             }
                         },
+                        // If balance is decreased with a negative
+                        // value, there's no way it is a nonexist
+                        // account.
                         AccountChange::DecreaseBalance(_, _) => panic!(),
                     }
                 } else {
@@ -418,6 +421,8 @@ impl<A: AccountPatch> AccountState<A> {
             Some(val) => {
                 match val {
                     &mut AccountChange::Nonexist(_) => (),
+                    // The above matches all cases in enum. FIXME when
+                    // there're more AccountChange variants added.
                     _ => panic!(),
                 }
                 *val = AccountChange::Create {
@@ -724,6 +729,8 @@ impl<A: AccountPatch> AccountState<A> {
                     nonce,
                 })
             },
+            // We cannot decrease balance of a nonexist account (with
+            // balance zero).
             Some(AccountChange::Nonexist(_)) => panic!(),
             None => {
                 Some(AccountChange::DecreaseBalance(address, withdraw))

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -552,7 +552,6 @@ impl<A: AccountPatch> AccountState<A> {
                         return ret;
                     }
                 }
-                _ => (),
             }
         }
 

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -79,6 +79,11 @@ impl Storage {
         self.storage.insert(index, value);
         Ok(())
     }
+
+    /// Return the number of changed/full items in storage.
+    pub fn len(&self) -> usize {
+        self.storage.len()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -325,6 +325,7 @@ impl<A: AccountPatch> AccountState<A> {
                 };
 
                 self.accounts.insert(address, account);
+                self.codes.remove(&address);
                 self.premarked_exists.remove(&address);
             },
             AccountCommitment::Code {
@@ -387,6 +388,7 @@ impl<A: AccountPatch> AccountState<A> {
                 };
 
                 self.accounts.insert(address, account);
+                self.codes.remove(&address);
                 self.premarked_exists.remove(&address);
             }
         }
@@ -601,6 +603,8 @@ impl<A: AccountPatch> AccountState<A> {
             return Err(RequireError::Account(address));
         };
 
+        self.codes.remove(&address);
+        self.premarked_exists.remove(&address);
         self.accounts.insert(address, account);
 
         Ok(())

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -506,6 +506,7 @@ impl<A: AccountPatch> AccountState<A> {
         return Err(RequireError::Account(address));
     }
 
+    /// Read a value from an account storage.
     pub fn storage_read(&self, address: Address, index: U256) -> Result<M256, RequireError> {
         if self.accounts.contains_key(&address) {
             match self.accounts.get(&address).unwrap() {
@@ -525,6 +526,8 @@ impl<A: AccountPatch> AccountState<A> {
         return Err(RequireError::Account(address));
     }
 
+    /// Write a value from an account storage. The account will be
+    /// created if it is nonexist.
     pub fn storage_write(&mut self, address: Address, index: U256, value: M256) -> Result<(), RequireError> {
         if self.accounts.contains_key(&address) {
             match self.accounts.get_mut(&address).unwrap() {

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -589,6 +589,11 @@ impl<A: AccountPatch> AccountState<A> {
                     }
                 },
                 _ => {
+                    // Although creation will clean up storage and
+                    // code, the balance will be added if it was
+                    // existing in prior. So if it is IncreaseBalance
+                    // or DecreaseBalance, we need to ask for the
+                    // account first.
                     return Err(RequireError::Account(address));
                 },
             }

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -606,7 +606,8 @@ impl<A: AccountPatch> AccountState<A> {
         Ok(())
     }
 
-    /// Deposit code in to a created account.
+    /// Deposit code in to a created account. Only usable in a newly
+    /// created account.
     pub fn code_deposit(&mut self, address: Address, new_code: Rc<Vec<u8>>) {
         match self.accounts.get_mut(&address).unwrap() {
             &mut AccountChange::Create { ref mut code, .. } => {
@@ -616,7 +617,8 @@ impl<A: AccountPatch> AccountState<A> {
         }
     }
 
-    /// Increase the balance of an account.
+    /// Increase the balance of an account. The account will be
+    /// created if it is nonexist in the beginning.
     pub fn increase_balance(&mut self, address: Address, topup: U256) {
         if topup == U256::zero() { return; }
         let account = match self.accounts.remove(&address) {
@@ -680,7 +682,8 @@ impl<A: AccountPatch> AccountState<A> {
         }
     }
 
-    /// Decrease the balance of an account.
+    /// Decrease the balance of an account. The account will be
+    /// created if it is nonexist in the beginning.
     pub fn decrease_balance(&mut self, address: Address, withdraw: U256) {
         if withdraw == U256::zero() { return; }
         let account = match self.accounts.remove(&address) {
@@ -737,7 +740,8 @@ impl<A: AccountPatch> AccountState<A> {
     }
 
     /// Set nonce of an account. If the account is not already
-    /// commited, returns a `RequireError`.
+    /// commited, returns a `RequireError`. The account will be
+    /// created if it is nonexist in the beginning.
     pub fn set_nonce(&mut self, address: Address, new_nonce: U256) -> Result<(), RequireError> {
         match self.accounts.get_mut(&address) {
             Some(&mut AccountChange::Full {
@@ -780,8 +784,7 @@ impl<A: AccountPatch> AccountState<A> {
     }
 
     /// Delete an account from this account state. The account is set
-    /// to null. If the account is not already commited, returns a
-    /// `RequireError`.
+    /// to null.
     pub fn remove(&mut self, address: Address) -> Result<(), RequireError> {
         self.codes.remove(&address);
         self.premarked_exists.remove(&address);

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -423,7 +423,7 @@ impl<A: AccountPatch> AccountState<A> {
                     &mut AccountChange::Nonexist(_) => (),
                     // The above matches all cases in enum. FIXME when
                     // there're more AccountChange variants added.
-                    _ => panic!(),
+                    _ => unreachable!(),
                 }
                 *val = AccountChange::Create {
                     nonce: A::initial_nonce(),

--- a/src/eval/cost.rs
+++ b/src/eval/cost.rs
@@ -39,7 +39,7 @@ fn sstore_cost<M: Memory + Default, P: Patch>(machine: &State<M, P>) -> Gas {
     let value = machine.stack.peek(1).unwrap();
     let address = machine.context.address;
 
-    if value != M256::zero() && machine.account_state.storage(address).unwrap().read(index).unwrap() == M256::zero() {
+    if value != M256::zero() && machine.account_state.storage_read(address, index).unwrap() == M256::zero() {
         G_SSET.into()
     } else {
         G_SRESET.into()
@@ -267,7 +267,7 @@ pub fn gas_refund<M: Memory + Default, P: Patch>(instruction: Instruction, state
             let value = state.stack.peek(1).unwrap();
             let address = state.context.address;
 
-            if value == M256::zero() && state.account_state.storage(address).unwrap().read(index).unwrap() != M256::zero() {
+            if value == M256::zero() && state.account_state.storage_read(address, index).unwrap() != M256::zero() {
                 Gas::from(R_SCLEAR)
             } else {
                 Gas::zero()

--- a/src/eval/run/flow.rs
+++ b/src/eval/run/flow.rs
@@ -7,13 +7,13 @@ use patch::Patch;
 
 pub fn sload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256);
-    let value = state.account_state.storage(state.context.address).unwrap().read(index).unwrap();
+    let value = state.account_state.storage_read(state.context.address, index).unwrap();
     push!(state, value);
 }
 
 pub fn sstore<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {
     pop!(state, index: U256, value: M256);
-    state.account_state.storage_mut(state.context.address).unwrap().write(index, value).unwrap();
+    state.account_state.storage_write(state.context.address, index, value).unwrap();
 }
 
 pub fn mload<M: Memory + Default, P: Patch>(state: &mut State<M, P>) {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -490,10 +490,9 @@ mod tests {
         assert_eq!(accounts.len(), 1);
         match accounts[0] {
             AccountChange::Create {
-                address, exists, balance, ..
+                address, balance, ..
             } => {
                 assert_eq!(address, Address::default());
-                assert_eq!(exists, true);
                 assert_eq!(balance, U256::from_str("0xffffffffffffffff").unwrap());
             },
             _ => panic!()

--- a/stateful/examples/parallel.rs
+++ b/stateful/examples/parallel.rs
@@ -51,11 +51,8 @@ pub enum SendableAccountChange {
         storage: Storage,
         /// Code associated with this account.
         code: Vec<u8>,
-        /// Whether, at this point, the account is considered
-        /// existing. The client should delete this address if this is
-        /// set to `false`.
-        exists: bool,
     },
+    Nonexist(Address),
 }
 
 impl SendableAccountChange {
@@ -72,6 +69,7 @@ impl SendableAccountChange {
                 address,
                 ..
             } => address,
+            &SendableAccountChange::Nonexist(address) => address,
         }
     }
 }
@@ -89,12 +87,13 @@ impl From<AccountChange> for SendableAccountChange {
                 SendableAccountChange::IncreaseBalance(address, balance),
             AccountChange::DecreaseBalance(address, balance) =>
                 SendableAccountChange::DecreaseBalance(address, balance),
-            AccountChange::Create { nonce, address, balance, storage, code, exists } => {
+            AccountChange::Create { nonce, address, balance, storage, code } => {
                 SendableAccountChange::Create {
-                    nonce, address, balance, storage, exists,
+                    nonce, address, balance, storage,
                     code: code.deref().clone()
                 }
             },
+            AccountChange::Nonexist(address) => SendableAccountChange::Nonexist(address),
         }
     }
 }
@@ -112,12 +111,13 @@ impl Into<AccountChange> for SendableAccountChange {
                 AccountChange::IncreaseBalance(address, balance),
             SendableAccountChange::DecreaseBalance(address, balance) =>
                 AccountChange::DecreaseBalance(address, balance),
-            SendableAccountChange::Create { nonce, address, balance, storage, code, exists } => {
+            SendableAccountChange::Create { nonce, address, balance, storage, code } => {
                 AccountChange::Create {
-                    nonce, address, balance, storage, exists,
+                    nonce, address, balance, storage,
                     code: Rc::new(code),
                 }
             },
+            SendableAccountChange::Nonexist(address) => AccountChange::Nonexist(address),
         }
     }
 }


### PR DESCRIPTION
* Separated `AccountChange::Create` (with the `exists` field) into `AccountChange::Create` and `AccountChange::Nonexist`. The first represents creating a new account from a nonexisting one. The second represents a committed nonexisting account or a suicided account.
* Added `Storage::len` function for convenience.