### PR TITLE
Simple profiling tool for SputnikVM

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ description = "SputnikVM CLI"
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [[bin]]
-name = "sputnikvm"
+name = "sputnikvm-cli"
 
 [dependencies]
 etcommon-bigint = "0.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,3 +16,4 @@ sputnikvm = { version = "0.9", path = ".." }
 gethrpc = { path = '../gethrpc' }
 clap = "2.22"
 serde_json = "0.9"
+flame = "0.2"

--- a/nightly.nix
+++ b/nightly.nix
@@ -29,6 +29,6 @@ in with pkgs;
 stdenv.mkDerivation {
   name = "sputnikvm-env";
   buildInputs = [
-    rustc cargo gdb openssl pkgconfig
+    rustc cargo gdb openssl pkgconfig valgrind
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,6 @@ in with pkgs;
 stdenv.mkDerivation {
   name = "sputnikvm-env";
   buildInputs = [
-    rustc cargo gdb openssl pkgconfig
+    rustc cargo gdb openssl pkgconfig valgrind
   ];
 }

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -7,6 +7,7 @@ use alloc::Vec;
 #[cfg(feature = "std")] use std::rc::Rc;
 
 use bigint::{M256, U256, Gas, Address};
+use super::pc::Instruction;
 use super::commit::{AccountState, BlockhashState};
 use super::errors::{RequireError, RuntimeError, CommitError, EvalOnChainError,
                     OnChainError, NotSupportedError};
@@ -236,6 +237,15 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
             }
         }
         return false;
+    }
+
+    pub fn peek(&self) -> Option<Instruction> {
+        let pc = PC::<P>::new(&self.state.context.code,
+                              &self.state.valids, &self.state.position);
+        match pc.peek() {
+            Ok(val) => Some(val),
+            Err(_) => None,
+        }
     }
 
     /// Step an instruction in the PC. The eval result is refected by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ pub trait VM {
     fn commit_blockhash(&mut self, number: U256, hash: H256) -> Result<(), CommitError>;
     /// Returns the current status of the VM.
     fn status(&self) -> VMStatus;
+    /// Read the next instruction to be executed.
+    fn peek(&self) -> Option<Instruction>;
     /// Run one instruction and return. If it succeeds, VM status can
     /// still be `Running`. If the call stack has more than one items,
     /// this will only executes the last items' one single
@@ -219,6 +221,15 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
             MachineStatus::ExitedOk => VMStatus::ExitedOk,
             MachineStatus::ExitedErr(err) => VMStatus::ExitedErr(err.into()),
             MachineStatus::ExitedNotSupported(err) => VMStatus::ExitedNotSupported(err),
+        }
+    }
+
+    fn peek(&self) -> Option<Instruction> {
+        match self.machines.last().unwrap().status().clone() {
+            MachineStatus::Running => {
+                self.machines.last().unwrap().peek()
+            },
+            _ => None,
         }
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -19,7 +19,8 @@ use super::errors::{RequireError, CommitError};
 use super::errors::PreExecutionError;
 use super::{State, Machine, Context, ContextVM, VM, AccountState,
             BlockhashState, Patch, HeaderParams, Memory, VMStatus,
-            AccountCommitment, Log, AccountChange, MachineStatus};
+            AccountCommitment, Log, AccountChange, MachineStatus,
+            Instruction};
 
 use block_core::TransactionAction;
 #[cfg(feature = "std")]
@@ -294,6 +295,13 @@ impl<M: Memory + Default, P: Patch> VM for TransactionVM<M, P> {
                 }
             },
             TransactionVMState::Constructing { .. } => VMStatus::Running,
+        }
+    }
+
+    fn peek(&self) -> Option<Instruction> {
+        match self.0 {
+            TransactionVMState::Running { ref vm, .. } => vm.peek(),
+            TransactionVMState::Constructing { .. } => None,
         }
     }
 


### PR DESCRIPTION
This adds a simple profiling tool for EVM instructions.

* The design goal is to create debugger functions in core *without introducing any additional dependencies* so in the future we can move cli out of core library again.
* Fix a bug in cli that caused `--code` to be ignored.
* Add `VM::peek` function that inspect the next instruction to be executed.
* Add cargo-profiler support through valgrind.
* Add flame support.

This can be used by passing the `--profile` argument to cli. It will output a file called `profile.html` that contains instruction time for each EVM instruction. Example usage:

```
cargo run -- --profile --patch eip160 --code 0x60e060020a6000350480632839e92814601e57806361047ff414603457005b602a6004356024356047565b8060005260206000f35b603d6004356099565b8060005260206000f35b600082600014605457605e565b8160010190506093565b81600014606957607b565b60756001840360016047565b90506093565b609060018403608c85600186036047565b6047565b90505b92915050565b6000816000148060a95750816001145b60b05760b7565b81905060cf565b60c1600283036099565b60cb600184036099565b0190505b91905056 --data 0x2839e92800000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000002
```

An interesting fact is that the result shows the instruction that takes a relatively long time is `PUSH`. This might indicate that there's a bug in the current profiler or `PUSH` is indeed slow. I'll get a good profiler and debugger tooling before attempting to optimize that.