### PR TITLE
Implement a profiler that outputs opcode usage stats

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -7,6 +7,8 @@ extern crate serde_json;
 extern crate gethrpc;
 extern crate flame;
 
+mod profiler;
+
 use std::fs::File;
 
 use bigint::{Gas, Address, U256, M256, H256};

--- a/cli/src/bin/profiler.rs
+++ b/cli/src/bin/profiler.rs
@@ -1,0 +1,30 @@
+use sputnikvm::Opcode;
+use std::collections::{HashMap, hash_map};
+use flame::Span;
+
+pub struct Profiler {
+    occurances: HashMap<Opcode, (usize, f64)>,
+}
+
+impl Default for Profiler {
+    fn default() -> Self {
+        Self {
+            occurances: Default::default(),
+        }
+    }
+}
+
+impl Profiler {
+    pub fn record(&mut self, opcode: Opcode, span: &Span) {
+        match self.occurances.entry(opcode) {
+            hash_map::Entry::Occupied(mut entry) => {
+                let (occ, avg) = entry.get().clone();
+                let (nocc, navg) = (occ + 1, ((avg * (occ as f64)) + (span.delta as f64)) / ((occ + 1) as f64));
+                entry.insert((nocc, navg));
+            },
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert((1, span.delta as f64));
+            },
+        }
+    }
+}

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -11,7 +11,8 @@ use super::pc::Instruction;
 use super::commit::{AccountState, BlockhashState};
 use super::errors::{RequireError, RuntimeError, CommitError, EvalOnChainError,
                     OnChainError, NotSupportedError};
-use super::{Stack, Context, HeaderParams, Patch, PC, PCMut, Valids, Memory, AccountCommitment, Log};
+use super::{Stack, Context, HeaderParams, Patch, PC, PCMut, Valids, Memory,
+            AccountCommitment, Log, Opcode};
 
 use self::check::{check_opcode, check_support, extra_check_opcode};
 use self::run::run_opcode;
@@ -243,6 +244,15 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         let pc = PC::<P>::new(&self.state.context.code,
                               &self.state.valids, &self.state.position);
         match pc.peek() {
+            Ok(val) => Some(val),
+            Err(_) => None,
+        }
+    }
+
+    pub fn peek_opcode(&self) -> Option<Opcode> {
+        let pc = PC::<P>::new(&self.state.context.code,
+                              &self.state.valids, &self.state.position);
+        match pc.peek_opcode() {
             Ok(val) => Some(val),
             Err(_) => None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,8 @@ pub trait VM {
     fn status(&self) -> VMStatus;
     /// Read the next instruction to be executed.
     fn peek(&self) -> Option<Instruction>;
+    /// Read the next opcode to be executed.
+    fn peek_opcode(&self) -> Option<Opcode>;
     /// Run one instruction and return. If it succeeds, VM status can
     /// still be `Running`. If the call stack has more than one items,
     /// this will only executes the last items' one single
@@ -228,6 +230,15 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
         match self.machines.last().unwrap().status().clone() {
             MachineStatus::Running => {
                 self.machines.last().unwrap().peek()
+            },
+            _ => None,
+        }
+    }
+
+    fn peek_opcode(&self) -> Option<Opcode> {
+        match self.machines.last().unwrap().status().clone() {
+            MachineStatus::Running => {
+                self.machines.last().unwrap().peek_opcode()
             },
             _ => None,
         }

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -145,13 +145,19 @@ impl<'a, P: Patch> PC<'a, P> {
         *self.position == self.code.len()
     }
 
-    /// Peek the next instruction.
-    pub fn peek(&self) -> Result<Instruction, OnChainError> {
+    /// Peek the next opcode.
+    pub fn peek_opcode(&self) -> Result<Opcode, OnChainError> {
         let position = self.position;
         if *position >= self.code.len() {
             return Err(OnChainError::PCOverflow);
         }
-        let opcode: Opcode = self.code[*position].into();
+        Ok(self.code[*position].into())
+    }
+
+    /// Peek the next instruction.
+    pub fn peek(&self) -> Result<Instruction, OnChainError> {
+        let position = self.position;
+        let opcode: Opcode = self.peek_opcode()?;
         Ok(match opcode {
             Opcode::STOP => Instruction::STOP,
             Opcode::ADD => Instruction::ADD,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -20,7 +20,7 @@ use super::errors::PreExecutionError;
 use super::{State, Machine, Context, ContextVM, VM, AccountState,
             BlockhashState, Patch, HeaderParams, Memory, VMStatus,
             AccountCommitment, Log, AccountChange, MachineStatus,
-            Instruction};
+            Instruction, Opcode};
 
 use block_core::TransactionAction;
 #[cfg(feature = "std")]
@@ -301,6 +301,13 @@ impl<M: Memory + Default, P: Patch> VM for TransactionVM<M, P> {
     fn peek(&self) -> Option<Instruction> {
         match self.0 {
             TransactionVMState::Running { ref vm, .. } => vm.peek(),
+            TransactionVMState::Constructing { .. } => None,
+        }
+    }
+
+    fn peek_opcode(&self) -> Option<Opcode> {
+        match self.0 {
+            TransactionVMState::Running { ref vm, .. } => vm.peek_opcode(),
             TransactionVMState::Constructing { .. } => None,
         }
     }

--- a/src/util/opcode.rs
+++ b/src/util/opcode.rs
@@ -1,6 +1,6 @@
 //! Ethereum opcodes
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 #[allow(missing_docs)]
 /// Opcode enum. One-to-one corresponding to an `u8` value.
 pub enum Opcode {


### PR DESCRIPTION
Implement a profiler that outputs average opcode execution time and opcode total encounters.

Example usage:

```
cargo run --release -- --profile --patch eip160 --code 0x60e060020a6000350480632839e92814601e57806361047ff414603457005b602a6004356024356047565b8060005260206000f35b603d6004356099565b8060005260206000f35b600082600014605457605e565b8160010190506093565b81600014606957607b565b60756001840360016047565b90506093565b609060018403608c85600186036047565b6047565b90505b92915050565b6000816000148060a95750816001145b60b05760b7565b81905060cf565b60c1600283036099565b60cb600184036099565b0190505b91905056 --data 0x2839e92800000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000002
```

Output:

```
--- Profiler Stats ---
Some(RETURN): 5554 ns (1 times)
Some(MSTORE): 3073 ns (1 times)
Some(EXP): 2093 ns (1 times)
Some(CALLDATALOAD): 1458 ns (3 times)
Some(DIV): 971 ns (1 times)
Some(DUP(1)): 899 ns (2 times)
Some(PUSH(1)): 434 ns (4928 times)
Some(EQ): 318 ns (825 times)
Some(JUMPI): 300 ns (825 times)
Some(SWAP(2)): 297 ns (541 times)
Some(PUSH(4)): 285 ns (1 times)
Some(SUB): 283 ns (540 times)
Some(JUMP): 283 ns (1906 times)
Some(ADD): 259 ns (258 times)
Some(SWAP(3)): 256 ns (541 times)
Some(JUMPDEST): 254 ns (2448 times)
Some(SWAP(1)): 251 ns (541 times)
Some(DUP(7)): 248 ns (257 times)
Some(DUP(6)): 245 ns (257 times)
Some(DUP(5)): 245 ns (283 times)
Some(DUP(3)): 243 ns (541 times)
Some(DUP(2)): 240 ns (541 times)
Some(POP): 239 ns (1623 times)
--- End Profiler Stats ---
```