### PR TITLE
Fixes related to exist/nonexist account checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.9.1"
+version = "0.9.2"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
 repository = "https://github.com/ethereumproject/sputnikvm"
-keywords = ["no_std"]
+keywords = ["no_std", "ethereum"]
 
 [lib]
 name = "sputnikvm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm"
-version = "0.9.2"
+version = "0.9.3"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -34,6 +34,8 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         if !self.state.context.is_system {
             self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
             self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
+        } else {
+            assert!(preclaimed_value == U256::zero());
         }
         self.state.account_state.increase_balance(self.state.context.address, self.state.context.value);
     }
@@ -56,6 +58,8 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         if !self.state.context.is_system {
             self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
             self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
+        } else {
+            assert!(preclaimed_value == U256::zero());
         }
         self.state.account_state.create(self.state.context.address, self.state.context.value).unwrap();
 
@@ -124,10 +128,12 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         if !self.state.context.is_system {
             self.state.account_state.increase_balance(self.state.context.caller, preclaimed_value);
             self.state.account_state.decrease_balance(self.state.context.caller, gas_dec.into());
-        }
 
-        // Apply miner rewards
-        self.state.account_state.increase_balance(beneficiary, gas_dec.into());
+            // Apply miner rewards
+            self.state.account_state.increase_balance(beneficiary, gas_dec.into());
+        } else {
+            assert!(preclaimed_value == U256::zero() && gas_dec == Gas::zero());
+        }
 
         for address in &self.state.removed {
             self.state.account_state.remove(*address).unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -51,6 +51,9 @@ macro_rules! system_address {
 /// 0xffffffffffffffffffffffffffffffffffffffff. As a result, when
 /// executing a message call or a contract creation, nonce are not
 /// changed. A SYSTEM transaction must have gas_price set to zero.
+/// Because the transaction reward is always zero, a SYSTEM
+/// transaction will also not invoke creation of the beneficiary
+/// address if it does not exist before.
 
 #[derive(Debug, Clone)]
 pub struct ValidTransaction {


### PR DESCRIPTION
* Fix an issue in transaction reward handling, in which a new account should still be created in edge cases.
* Fix an issue related to SYSTEM transaction, where the account exist/nonexist rule differs for the SYSTEM address.