### PR TITLE
TransactionVM::new_from_unknown which deals with potentially invalid transactions

### DIFF
--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -34,8 +34,6 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         if !self.state.context.is_system {
             self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
             self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
-        } else {
-            assert!(preclaimed_value == U256::zero());
         }
         self.state.account_state.increase_balance(self.state.context.address, self.state.context.value);
     }
@@ -58,8 +56,6 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         if !self.state.context.is_system {
             self.state.account_state.decrease_balance(self.state.context.caller, preclaimed_value);
             self.state.account_state.decrease_balance(self.state.context.caller, self.state.context.value);
-        } else {
-            assert!(preclaimed_value == U256::zero());
         }
         self.state.account_state.create(self.state.context.address, self.state.context.value).unwrap();
 
@@ -131,8 +127,6 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
 
             // Apply miner rewards
             self.state.account_state.increase_balance(beneficiary, gas_dec.into());
-        } else {
-            assert!(preclaimed_value == U256::zero() && gas_dec == Gas::zero());
         }
 
         for address in &self.state.removed {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -285,6 +285,19 @@ enum TransactionVMState<M, P: Patch> {
 pub struct TransactionVM<M, P: Patch>(TransactionVMState<M, P>);
 
 impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
+    pub fn new_from_unknown(transaction: VMTransaction, block: HeaderParams) -> Option<Self> {
+        let valid = transaction.to_valid::<P>()?;
+        let mut vm = TransactionVM(TransactionVMState::Constructing {
+            transaction: valid,
+            block: block,
+
+            account_state: AccountState::default(),
+            blockhash_state: BlockhashState::default(),
+        });
+        vm.commit_account(transaction.caller).unwrap();
+        Some(vm)
+    }
+
     /// Create a new VM using the given transaction, block header and
     /// patch. This VM runs at the transaction level.
     pub fn new(transaction: ValidTransaction, block: HeaderParams) -> Self {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -131,16 +131,16 @@ impl ValidTransaction {
     /// Create a valid transaction from a block transaction. Caller is
     /// always Some.
     pub fn from_transaction<P: Patch>(
-        transaction: &Transaction, caller_nonce: U256, caller_balance: U256
-    ) -> Result<ValidTransaction, PreExecutionError> {
+        transaction: &Transaction, account_state: &AccountState<P::Account>
+    ) -> Result<Result<ValidTransaction, PreExecutionError>, RequireError> {
         let caller = match transaction.caller() {
             Ok(val) => val,
-            Err(_) => return Err(PreExecutionError::InvalidCaller),
+            Err(_) => return Ok(Err(PreExecutionError::InvalidCaller)),
         };
 
-        let nonce = caller_nonce;
+        let nonce = account_state.nonce(caller)?;
         if nonce != transaction.nonce {
-            return Err(PreExecutionError::InvalidNonce);
+            return Ok(Err(PreExecutionError::InvalidNonce));
         }
 
         let valid = ValidTransaction {
@@ -154,10 +154,10 @@ impl ValidTransaction {
         };
 
         if valid.gas_limit < valid.intrinsic_gas::<P>() {
-            return Err(PreExecutionError::InsufficientGasLimit);
+            return Ok(Err(PreExecutionError::InsufficientGasLimit));
         }
 
-        let balance = caller_balance;
+        let balance = account_state.balance(caller)?;
 
         let gas_limit: U256 = valid.gas_limit.into();
         let gas_price: U256 = valid.gas_price.into();
@@ -165,14 +165,14 @@ impl ValidTransaction {
         let (preclaimed_value, overflowed1) = gas_limit.overflowing_mul(gas_price);
         let (total, overflowed2) = preclaimed_value.overflowing_add(valid.value);
         if overflowed1 || overflowed2 {
-            return Err(PreExecutionError::InsufficientBalance);
+            return Ok(Err(PreExecutionError::InsufficientBalance));
         }
 
         if balance < total {
-            return Err(PreExecutionError::InsufficientBalance);
+            return Ok(Err(PreExecutionError::InsufficientBalance));
         }
 
-        Ok(valid)
+        Ok(Ok(valid))
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -257,9 +257,7 @@ impl ValidTransaction {
     /// When the execution of a transaction begins, this preclaimed
     /// value is deducted from the account.
     pub fn preclaimed_value(&self) -> U256 {
-        let gas_limit: U256 = self.gas_limit.into();
-        let gas_price: U256 = self.gas_price.into();
-        (gas_limit.saturating_mul(gas_price)).into()
+        (self.gas_limit * self.gas_price).into()
     }
 }
 


### PR DESCRIPTION
Fix #298.

* Includes various fixes for upper library use of transaction conversions.
* new_from_unknown now deals with invalid transactions.