### PR TITLE
Remove DecreaseBalance AccountChange

### DIFF
--- a/jsontests/src/blockchain.rs
+++ b/jsontests/src/blockchain.rs
@@ -113,10 +113,6 @@ impl JSONBlock {
                 let balance = self.balance(address);
                 self.set_balance(address, balance + topup);
             },
-            AccountChange::DecreaseBalance(address, withdraw) => {
-                let balance = self.balance(address);
-                self.set_balance(address, balance - withdraw);
-            },
         }
     }
 

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -224,17 +224,6 @@ fn test_block<T: GethRPCClient, P: Patch>(client: &mut T, number: usize) {
                                 U256::from_str(&cur_balance).unwrap());
                     }
                 },
-                &AccountChange::DecreaseBalance(address, balance) => {
-                    if !is_miner_or_uncle(client, address, &block) {
-                        let last_balance = client.get_balance(&format!("0x{:x}", address),
-                                                              &last_number);
-                        let cur_balance = client.get_balance(&format!("0x{:x}", address),
-                                                             &cur_number);
-
-                        assert!(U256::from_str(&last_balance).unwrap() - balance ==
-                                U256::from_str(&cur_balance).unwrap());
-                    }
-                },
                 &AccountChange::Nonexist(address) => {
                     if !is_miner_or_uncle(client, address, &block) {
                         let expected_balance = client.get_balance(&format!("0x{:x}", address),

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -28,6 +28,9 @@ use super::cost::code_deposit_gas;
 
 impl<M: Memory + Default, P: Patch> Machine<M, P> {
     /// Initialize a MessageCall transaction.
+    ///
+    /// ### Panic
+    /// Requires caller of the transaction to be committed.
     pub fn initialize_call(&mut self, preclaimed_value: U256) {
         self.state.account_state.premark_exists(self.state.context.address);
 
@@ -39,6 +42,9 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Initialize the runtime as a call from a CALL or CALLCODE opcode.
+    ///
+    /// ### Panic
+    /// Requires caller of the CALL/CALLCODE opcode to be committed.
     pub fn invoke_call(&mut self) {
         self.state.account_state.premark_exists(self.state.context.address);
 
@@ -49,6 +55,9 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Initialize a ContractCreation transaction.
+    ///
+    /// ### Panic
+    /// Requires caller of the transaction to be committed.
     pub fn initialize_create(&mut self, preclaimed_value: U256) -> Result<(), RequireError> {
         self.state.account_state.require(self.state.context.address)?;
 
@@ -63,6 +72,9 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Initialize the runtime as a call from a CREATE opcode.
+    ///
+    /// ### Panic
+    /// Requires caller of the CREATE opcode to be committed.
     pub fn invoke_create(&mut self) -> Result<(), RequireError> {
         self.state.account_state.require(self.state.context.address)?;
 
@@ -98,6 +110,9 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
 
     /// Finalize a transaction. This should not be used when invoked
     /// by an opcode.
+    ///
+    /// ### Panic
+    /// Requires caller of the transaction to be committed.
     pub fn finalize(&mut self, beneficiary: Address, real_used_gas: Gas, preclaimed_value: U256, fresh_account_state: &AccountState<P::Account>) -> Result<(), RequireError> {
         self.state.account_state.require(self.state.context.address)?;
 

--- a/stateful/examples/parallel.rs
+++ b/stateful/examples/parallel.rs
@@ -37,8 +37,6 @@ pub enum SendableAccountChange {
     },
     /// Only balance is changed, and it is increasing for this address.
     IncreaseBalance(Address, U256),
-    /// Only balance is changed, and it is decreasing for this address.
-    DecreaseBalance(Address, U256),
     /// Create or delete a (new) account.
     Create {
         /// Account nonce.
@@ -64,7 +62,6 @@ impl SendableAccountChange {
                 ..
             } => address,
             &SendableAccountChange::IncreaseBalance(address, _) => address,
-            &SendableAccountChange::DecreaseBalance(address, _) => address,
             &SendableAccountChange::Create {
                 address,
                 ..
@@ -85,8 +82,6 @@ impl From<AccountChange> for SendableAccountChange {
             },
             AccountChange::IncreaseBalance(address, balance) =>
                 SendableAccountChange::IncreaseBalance(address, balance),
-            AccountChange::DecreaseBalance(address, balance) =>
-                SendableAccountChange::DecreaseBalance(address, balance),
             AccountChange::Create { nonce, address, balance, storage, code } => {
                 SendableAccountChange::Create {
                     nonce, address, balance, storage,
@@ -109,8 +104,6 @@ impl Into<AccountChange> for SendableAccountChange {
             },
             SendableAccountChange::IncreaseBalance(address, balance) =>
                 AccountChange::IncreaseBalance(address, balance),
-            SendableAccountChange::DecreaseBalance(address, balance) =>
-                AccountChange::DecreaseBalance(address, balance),
             SendableAccountChange::Create { nonce, address, balance, storage, code } => {
                 AccountChange::Create {
                     nonce, address, balance, storage,

--- a/stateful/src/lib.rs
+++ b/stateful/src/lib.rs
@@ -324,13 +324,6 @@ impl<'b, D: DatabaseOwned> Stateful<'b, D> {
                         }
                     }
                 },
-                AccountChange::DecreaseBalance(address, value) => {
-                    let mut account: Account = state.get(&address).unwrap();
-
-                    account.balance = account.balance - value;
-
-                    state.insert(address, account);
-                },
                 AccountChange::Create {
                     nonce, address, balance, storage, code
                 } => {


### PR DESCRIPTION
Summary: A simple analysis showed that DecreaseBalance variant in AccountChange is never used. Hence we remove it. This also gives ways to implement EIP161.