### PR TITLE
EIP161 implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,9 +264,9 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                 Ok(())
             },
             MachineStatus::InvokeCall(context, _) => {
-                self.history.push(context.clone());
-                let mut sub = self.machines.last().unwrap().derive(context);
-                sub.invoke_call();
+                let mut sub = self.machines.last().unwrap().derive(context.clone());
+                sub.invoke_call()?;
+                self.history.push(context);
                 self.machines.push(sub);
                 Ok(())
             },

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -13,12 +13,22 @@ use bigint::{Address, Gas, U256, H160};
 pub trait AccountPatch {
     /// Initial nonce for accounts.
     fn initial_nonce() -> U256;
+    /// Initial create nonce for accounts. (EIP161.a)
+    fn initial_create_nonce() -> U256;
+    /// Whether empty accounts are considered to be existing. (EIP161.b/EIP161.c/EIP161.d)
+    fn empty_considered_exists() -> bool;
+    /// Whether to allow partial change IncreaseBalance.
+    fn allow_partial_change() -> bool {
+        Self::empty_considered_exists()
+    }
 }
 
 /// Mainnet account patch
 pub struct MainnetAccountPatch;
 impl AccountPatch for MainnetAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
 }
 
 /// Represents different block range context.

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -462,7 +462,7 @@ impl<M: Memory + Default, P: Patch> VM for TransactionVM<M, P> {
         if ccode_deposit {
             vm.machines[0].initialize_create(cpreclaimed_value).unwrap();
         } else {
-            vm.machines[0].initialize_call(cpreclaimed_value);
+            vm.machines[0].initialize_call(cpreclaimed_value).unwrap();
         }
 
         self.0 = TransactionVMState::Running {

--- a/stateful/tests/genesis.rs
+++ b/stateful/tests/genesis.rs
@@ -66,6 +66,8 @@ fn morden_state_root() {
         struct MordenAccountPatch;
         impl AccountPatch for MordenAccountPatch {
             fn initial_nonce() -> U256 { U256::from(2u64.pow(20)) }
+            fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+            fn empty_considered_exists() -> bool { true }
         }
 
         let address = Address::from_str(key).unwrap();


### PR DESCRIPTION
Summary:
This implements [EIP161](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md). Several notes:

* `AccountPatch::initial_create_nonce` handles EIP161(a).
* `AccountPatch::empty_considered_exists` handles EIP161(b)(c)(d).
* `AccountPatch::allow_partial_change` specify whether AccountChange::IncreaseBalance can happen. However, if in the case of EIP161 being enabled, allowing this would mean that the client needs to check for zero balance accounts in the end touched by IncreaseBalance to comply EIP161(d).
* `AccountPatch::allow_partial_change` also has impact on parallel execution. When it is disabled, parallel execution would be slow due to the dependency on beneficiary address. If a client decides to take advantage of SputnikVM's parallel execution, it is recommended to always enable this and deal with EIP161(d).
* premark_exists is removed as it is not needed any more.