### PR TITLE
EIP170 implementation

### DIFF
--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -96,6 +96,13 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
             _ => panic!(),
         }
 
+        if P::code_deposit_limit().is_some() {
+            if self.state.out.len() > P::code_deposit_limit().unwrap() {
+                self.status = MachineStatus::ExitedErr(OnChainError::EmptyGas);
+                return;
+            }
+        }
+
         let deposit_cost = code_deposit_gas(self.state.out.len());
         if deposit_cost > self.state.available_gas() {
             if !P::force_code_deposit() {

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -36,6 +36,8 @@ pub trait Patch {
     /// Account patch
     type Account: AccountPatch;
 
+    /// Maximum contract size.
+    fn code_deposit_limit() -> Option<usize>;
     /// Limit of the call stack.
     fn callstack_limit() -> usize;
     /// Gas paid for extcode.
@@ -94,6 +96,7 @@ pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for FrontierPatch<A> {
     type Account = A;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -118,6 +121,7 @@ pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for HomesteadPatch<A> {
     type Account = A;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -141,6 +145,7 @@ pub struct VMTestPatch;
 impl Patch for VMTestPatch {
     type Account = MainnetAccountPatch;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 2 }
     fn gas_extcode() -> Gas { Gas::from(20usize) }
     fn gas_balance() -> Gas { Gas::from(20usize) }
@@ -165,6 +170,7 @@ pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for EIP150Patch<A> {
     type Account = A;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(700usize) }
     fn gas_balance() -> Gas { Gas::from(400usize) }
@@ -189,6 +195,7 @@ pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for EIP160Patch<A> {
     type Account = A;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(700usize) }
     fn gas_balance() -> Gas { Gas::from(400usize) }
@@ -215,6 +222,7 @@ pub type MainnetEmbeddedPatch = EmbeddedPatch<MainnetAccountPatch>;
 impl<A: AccountPatch> Patch for EmbeddedPatch<A> {
     type Account = A;
 
+    fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }
     fn gas_extcode() -> Gas { Gas::from(700usize) }
     fn gas_balance() -> Gas { Gas::from(400usize) }


### PR DESCRIPTION
Summary: The implements contract size limit. `Patch::deposit_code_limit` controls the maximum size of contract code. For Foundation's chain, this should be set to `0x6000`.