### PR TITLE
Specify patches for supported networks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,10 @@ members = [
   "./cli",
   "./precompiled/modexp",
   "./precompiled/bn128",
+  "./network/foundation",
+  "./network/classic",
+  "./network/ellaism",
+  "./network/musicoin",
+  "./network/expanse",
+  "./network/ubiq",
 ]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ experience of the community and learn from other proposed RFCs.
  * FFI, Protobuf and JSON interface
  * written in Rust, can be used as a binary, cargo crate or shared library  
 
+## Supported Networks
+
+* [Foundation](./network/foundation)
+* [Classic](./network/classic)
+* [Ellaism](./network/ellaism)
+* [Expanse](./network/expanse)
+* [Musicoin](./network/musicoin)
+* [Ubiq](./network/ubiq)
+
 ## Related projects
 
  * [SputnikVM Dev](https://github.com/ethereumproject/sputnikvm-dev) - SputnikVM instance for Smart Contract development, 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "sputnikvm-cli"
 etcommon-bigint = "0.2"
 etcommon-hexutil = "0.2"
 sputnikvm = { version = "0.9", path = ".." }
+sputnikvm-network-classic = { path = "../network/classic" }
 gethrpc = { path = '../gethrpc' }
 clap = "2.22"
 serde_json = "0.9"

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 extern crate bigint;
 extern crate hexutil;
 extern crate sputnikvm;
+extern crate sputnikvm_network_classic;
 extern crate serde_json;
 extern crate gethrpc;
 extern crate flame;
@@ -16,8 +17,8 @@ use bigint::{Gas, Address, U256, M256, H256};
 use hexutil::read_hex;
 use sputnikvm::{HeaderParams, Context, SeqTransactionVM, ValidTransaction, VM, Log, Patch,
                 AccountCommitment, AccountChange, RequireError, TransactionAction, VMStatus,
-                MainnetFrontierPatch, MainnetHomesteadPatch, MainnetEIP150Patch, MainnetEIP160Patch,
                 SeqContextVM};
+use sputnikvm_network_classic::{MainnetFrontierPatch, MainnetHomesteadPatch, MainnetEIP150Patch, MainnetEIP160Patch};
 use gethrpc::{GethRPCClient, NormalGethRPCClient, RPCBlock};
 use std::str::FromStr;
 use std::ops::DerefMut;

--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sputnikvm-network-classic"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/classic/src/lib.rs
+++ b/network/classic/src/lib.rs
@@ -1,0 +1,153 @@
+extern crate bigint;
+extern crate sputnikvm;
+
+use std::marker::PhantomData;
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+
+/// Mainnet account patch
+pub struct MainnetAccountPatch;
+impl AccountPatch for MainnetAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+pub struct MordenAccountPatch;
+impl AccountPatch for MordenAccountPatch {
+    fn initial_nonce() -> U256 { U256::from(1048576) }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+/// Frontier patch.
+pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
+pub type MordenFrontierPatch = FrontierPatch<MordenAccountPatch>;
+impl<A: AccountPatch> Patch for FrontierPatch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(0usize) }
+    fn force_code_deposit() -> bool { true }
+    fn has_delegate_call() -> bool { false }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &ETC_PRECOMPILEDS }
+}
+
+/// Homestead patch.
+pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
+pub type MordenHomesteadPatch = HomesteadPatch<MordenAccountPatch>;
+impl<A: AccountPatch> Patch for HomesteadPatch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &ETC_PRECOMPILEDS }
+}
+
+/// EIP150 patch.
+pub struct EIP150Patch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
+pub type MordenEIP150Patch = EIP150Patch<MordenAccountPatch>;
+impl<A: AccountPatch> Patch for EIP150Patch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &ETC_PRECOMPILEDS }
+}
+
+/// EIP160 patch.
+pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
+pub type MordenEIP160Patch = EIP160Patch<MordenAccountPatch>;
+impl<A: AccountPatch> Patch for EIP160Patch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &ETC_PRECOMPILEDS }
+}

--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sputnikvm-network-ellaism"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/ellaism/src/lib.rs
+++ b/network/ellaism/src/lib.rs
@@ -1,0 +1,58 @@
+extern crate bigint;
+extern crate sputnikvm;
+
+use std::marker::PhantomData;
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+
+pub static ELLA_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+/// Mainnet account patch
+pub struct MainnetAccountPatch;
+impl AccountPatch for MainnetAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+/// EIP160 patch.
+pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for EIP160Patch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &ELLA_PRECOMPILEDS }
+}

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sputnikvm-network-expanse"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+sputnikvm-precompiled-bn128 = { path = "../../precompiled/bn128" }
+sputnikvm-precompiled-modexp = { path = "../../precompiled/modexp" }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/expanse/src/lib.rs
+++ b/network/expanse/src/lib.rs
@@ -1,0 +1,174 @@
+extern crate bigint;
+extern crate sputnikvm;
+extern crate sputnikvm_precompiled_modexp;
+extern crate sputnikvm_precompiled_bn128;
+
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+use sputnikvm_precompiled_modexp::MODEXP_PRECOMPILED;
+use sputnikvm_precompiled_bn128::{BN128_ADD_PRECOMPILED, BN128_MUL_PRECOMPILED, BN128_PAIRING_PRECOMPILED};
+
+pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 8] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x05]),
+     None,
+     &MODEXP_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x06]),
+     None,
+     &BN128_ADD_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x07]),
+     None,
+     &BN128_MUL_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x08]),
+     None,
+     &BN128_PAIRING_PRECOMPILED),
+];
+
+pub struct FrontierAccountPatch;
+impl AccountPatch for FrontierAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+pub struct StateClearingAccountPatch;
+impl AccountPatch for StateClearingAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
+    fn empty_considered_exists() -> bool { false }
+}
+
+/// Frontier patch.
+pub struct FrontierPatch;
+impl Patch for FrontierPatch {
+    type Account = FrontierAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(0usize) }
+    fn force_code_deposit() -> bool { true }
+    fn has_delegate_call() -> bool { false }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Homestead patch.
+pub struct HomesteadPatch;
+impl Patch for HomesteadPatch {
+    type Account = FrontierAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Spurious Dragon patch.
+pub struct SpuriousDragonPatch;
+impl Patch for SpuriousDragonPatch {
+    type Account = StateClearingAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { Some(0x6000) }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Spurious Dragon patch.
+pub struct ByzantiumPatch;
+impl Patch for ByzantiumPatch {
+    type Account = StateClearingAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { Some(0x6000) }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { true }
+    fn has_revert() -> bool { true }
+    fn has_return_data() -> bool { true }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &BYZANTIUM_PRECOMPILEDS }
+}

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sputnikvm-network-foundation"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+sputnikvm-precompiled-bn128 = { path = "../../precompiled/bn128" }
+sputnikvm-precompiled-modexp = { path = "../../precompiled/modexp" }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/foundation/src/lib.rs
+++ b/network/foundation/src/lib.rs
@@ -1,0 +1,201 @@
+extern crate bigint;
+extern crate sputnikvm;
+extern crate sputnikvm_precompiled_modexp;
+extern crate sputnikvm_precompiled_bn128;
+
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+use sputnikvm_precompiled_modexp::MODEXP_PRECOMPILED;
+use sputnikvm_precompiled_bn128::{BN128_ADD_PRECOMPILED, BN128_MUL_PRECOMPILED, BN128_PAIRING_PRECOMPILED};
+
+pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+pub static BYZANTIUM_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 8] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x05]),
+     None,
+     &MODEXP_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x06]),
+     None,
+     &BN128_ADD_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x07]),
+     None,
+     &BN128_MUL_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x08]),
+     None,
+     &BN128_PAIRING_PRECOMPILED),
+];
+
+pub struct FrontierAccountPatch;
+impl AccountPatch for FrontierAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+pub struct StateClearingAccountPatch;
+impl AccountPatch for StateClearingAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
+    fn empty_considered_exists() -> bool { false }
+}
+
+/// Frontier patch.
+pub struct FrontierPatch;
+impl Patch for FrontierPatch {
+    type Account = FrontierAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(0usize) }
+    fn force_code_deposit() -> bool { true }
+    fn has_delegate_call() -> bool { false }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Homestead patch.
+pub struct HomesteadPatch;
+impl Patch for HomesteadPatch {
+    type Account = FrontierAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// EIP150 patch.
+pub struct EIP150Patch;
+impl Patch for EIP150Patch {
+    type Account = FrontierAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Spurious Dragon patch.
+pub struct SpuriousDragonPatch;
+impl Patch for SpuriousDragonPatch {
+    type Account = StateClearingAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { Some(0x6000) }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}
+
+/// Spurious Dragon patch.
+pub struct ByzantiumPatch;
+impl Patch for ByzantiumPatch {
+    type Account = StateClearingAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { Some(0x6000) }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { true }
+    fn has_revert() -> bool { true }
+    fn has_return_data() -> bool { true }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &BYZANTIUM_PRECOMPILEDS }
+}

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sputnikvm-network-musicoin"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/musicoin/src/lib.rs
+++ b/network/musicoin/src/lib.rs
@@ -1,0 +1,86 @@
+extern crate bigint;
+extern crate sputnikvm;
+
+use std::marker::PhantomData;
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+
+/// Mainnet account patch
+pub struct MainnetAccountPatch;
+impl AccountPatch for MainnetAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() }
+    fn empty_considered_exists() -> bool { true }
+}
+
+pub static MUSIC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+/// Frontier patch.
+pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for FrontierPatch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(0usize) }
+    fn force_code_deposit() -> bool { true }
+    fn has_delegate_call() -> bool { false }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &MUSIC_PRECOMPILEDS }
+}
+
+/// Homestead patch.
+pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
+pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
+impl<A: AccountPatch> Patch for HomesteadPatch<A> {
+    type Account = A;
+
+    fn code_deposit_limit() -> Option<usize> { None }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(20usize) }
+    fn gas_balance() -> Gas { Gas::from(20usize) }
+    fn gas_sload() -> Gas { Gas::from(50usize) }
+    fn gas_suicide() -> Gas { Gas::from(0usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
+    fn gas_call() -> Gas { Gas::from(40usize) }
+    fn gas_expbyte() -> Gas { Gas::from(10usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { true }
+    fn call_create_l64_after_gas() -> bool { false }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &MUSIC_PRECOMPILEDS }
+}

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sputnikvm-network-ubiq"
+version = "0.0.1"
+license = "Apache-2.0"
+authors = ["Wei Tang <hi@that.world>"]
+repository = "https://github.com/ethereumproject/sputnikvm"
+
+[dependencies]
+sputnikvm = { version = "0.9", path = "../.." }
+etcommon-bigint = { version = "0.2", default-features = false }

--- a/network/ubiq/src/lib.rs
+++ b/network/ubiq/src/lib.rs
@@ -1,0 +1,55 @@
+extern crate bigint;
+extern crate sputnikvm;
+
+use bigint::{Gas, U256, H160, Address};
+use sputnikvm::{Precompiled, AccountPatch, Patch,
+                ID_PRECOMPILED, ECREC_PRECOMPILED, SHA256_PRECOMPILED, RIP160_PRECOMPILED};
+
+pub static FRONTIER_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
+     None,
+     &ECREC_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x02]),
+     None,
+     &SHA256_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x03]),
+     None,
+     &RIP160_PRECOMPILED),
+    (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x04]),
+     None,
+     &ID_PRECOMPILED),
+];
+
+pub struct StateClearingAccountPatch;
+impl AccountPatch for StateClearingAccountPatch {
+    fn initial_nonce() -> U256 { U256::zero() }
+    fn initial_create_nonce() -> U256 { Self::initial_nonce() + U256::from(1) }
+    fn empty_considered_exists() -> bool { false }
+}
+
+/// Spurious Dragon patch.
+pub struct SpuriousDragonPatch;
+impl Patch for SpuriousDragonPatch {
+    type Account = StateClearingAccountPatch;
+
+    fn code_deposit_limit() -> Option<usize> { Some(0x6000) }
+    fn callstack_limit() -> usize { 1024 }
+    fn gas_extcode() -> Gas { Gas::from(700usize) }
+    fn gas_balance() -> Gas { Gas::from(400usize) }
+    fn gas_sload() -> Gas { Gas::from(200usize) }
+    fn gas_suicide() -> Gas { Gas::from(5000usize) }
+    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
+    fn gas_call() -> Gas { Gas::from(700usize) }
+    fn gas_expbyte() -> Gas { Gas::from(50usize) }
+    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
+    fn force_code_deposit() -> bool { false }
+    fn has_delegate_call() -> bool { true }
+    fn has_static_call() -> bool { false }
+    fn has_revert() -> bool { false }
+    fn has_return_data() -> bool { false }
+    fn err_on_call_with_more_gas() -> bool { false }
+    fn call_create_l64_after_gas() -> bool { true }
+    fn memory_limit() -> usize { usize::max_value() }
+    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
+        &FRONTIER_PRECOMPILEDS }
+}

--- a/precompiled/bn128/src/lib.rs
+++ b/precompiled/bn128/src/lib.rs
@@ -8,6 +8,8 @@ use bigint::{Gas, U256};
 use sputnikvm::Precompiled;
 use sputnikvm::errors::{OnChainError, RuntimeError, NotSupportedError};
 
+pub static BN128_ADD_PRECOMPILED: Bn128AddPrecompiled = Bn128AddPrecompiled;
+
 pub struct Bn128AddPrecompiled;
 impl Precompiled for Bn128AddPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
@@ -54,6 +56,8 @@ impl Precompiled for Bn128AddPrecompiled {
     }
 }
 
+pub static BN128_MUL_PRECOMPILED: Bn128MulPrecompiled = Bn128MulPrecompiled;
+
 pub struct Bn128MulPrecompiled;
 impl Precompiled for Bn128MulPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
@@ -92,6 +96,8 @@ impl Precompiled for Bn128MulPrecompiled {
         Ok((gas, Rc::new(output)))
     }
 }
+
+pub static BN128_PAIRING_PRECOMPILED: Bn128PairingPrecompiled = Bn128PairingPrecompiled;
 
 pub struct Bn128PairingPrecompiled;
 impl Precompiled for Bn128PairingPrecompiled {

--- a/precompiled/modexp/src/lib.rs
+++ b/precompiled/modexp/src/lib.rs
@@ -8,6 +8,8 @@ use bigint::{Gas, U256};
 use sputnikvm::Precompiled;
 use sputnikvm::errors::{OnChainError, RuntimeError, NotSupportedError};
 
+pub static MODEXP_PRECOMPILED: ModexpPrecompiled = ModexpPrecompiled;
+
 pub struct ModexpPrecompiled;
 impl Precompiled for ModexpPrecompiled {
     fn gas_and_step(&self, data: &[u8], gas_limit: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {

--- a/regtests/Cargo.toml
+++ b/regtests/Cargo.toml
@@ -10,6 +10,7 @@ name = "regtests"
 
 [dependencies]
 sputnikvm = { path = '..' }
+sputnikvm-network-classic = { path = "../network/classic" }
 gethrpc = { path = '../gethrpc' }
 etcommon-block = "0.3"
 etcommon-bigint = "0.2"

--- a/regtests/src/bin/main.rs
+++ b/regtests/src/bin/main.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate clap;
 extern crate sputnikvm;
+extern crate sputnikvm_network_classic;
 extern crate serde_json;
 extern crate gethrpc;
 extern crate block;
@@ -20,8 +21,9 @@ use block::TransactionAction;
 use bigint::{Gas, Address, U256, M256, H256};
 use hexutil::*;
 use sputnikvm::{HeaderParams, Context, SeqTransactionVM, ValidTransaction, VM, Log, Patch,
-                AccountCommitment, AccountChange, MainnetFrontierPatch, MainnetHomesteadPatch,
-                MainnetEIP150Patch, MainnetEIP160Patch};
+                AccountCommitment, AccountChange};
+use sputnikvm_network_classic::{MainnetFrontierPatch, MainnetHomesteadPatch,
+                                MainnetEIP150Patch, MainnetEIP160Patch};
 use sputnikvm::errors::RequireError;
 use gethrpc::{GethRPCClient, NormalGethRPCClient, RecordGethRPCClient, CachedGethRPCClient, RPCCall, RPCBlock, RPCTransaction, RPCLog};
 

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -5,8 +5,6 @@ mod precompiled;
 
 pub use self::precompiled::*;
 
-#[cfg(feature = "std")] use std::marker::PhantomData;
-#[cfg(not(feature = "std"))] use core::marker::PhantomData;
 use bigint::{Address, Gas, U256, H160};
 
 /// Account patch for account related variables.
@@ -24,8 +22,8 @@ pub trait AccountPatch {
 }
 
 /// Mainnet account patch
-pub struct MainnetAccountPatch;
-impl AccountPatch for MainnetAccountPatch {
+pub struct EmbeddedAccountPatch;
+impl AccountPatch for EmbeddedAccountPatch {
     fn initial_nonce() -> U256 { U256::zero() }
     fn initial_create_nonce() -> U256 { Self::initial_nonce() }
     fn empty_considered_exists() -> bool { true }
@@ -81,7 +79,7 @@ pub trait Patch {
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)];
 }
 
-pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
+pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,
      &ECREC_PRECOMPILED),
@@ -96,66 +94,10 @@ pub static ETC_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompi
      &ID_PRECOMPILED),
 ];
 
-/// Frontier patch.
-pub struct FrontierPatch<A: AccountPatch>(PhantomData<A>);
-pub type MainnetFrontierPatch = FrontierPatch<MainnetAccountPatch>;
-impl<A: AccountPatch> Patch for FrontierPatch<A> {
-    type Account = A;
-
-    fn code_deposit_limit() -> Option<usize> { None }
-    fn callstack_limit() -> usize { 1024 }
-    fn gas_extcode() -> Gas { Gas::from(20usize) }
-    fn gas_balance() -> Gas { Gas::from(20usize) }
-    fn gas_sload() -> Gas { Gas::from(50usize) }
-    fn gas_suicide() -> Gas { Gas::from(0usize) }
-    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
-    fn gas_call() -> Gas { Gas::from(40usize) }
-    fn gas_expbyte() -> Gas { Gas::from(10usize) }
-    fn gas_transaction_create() -> Gas { Gas::from(0usize) }
-    fn force_code_deposit() -> bool { true }
-    fn has_delegate_call() -> bool { false }
-    fn has_static_call() -> bool { false }
-    fn has_revert() -> bool { false }
-    fn has_return_data() -> bool { false }
-    fn err_on_call_with_more_gas() -> bool { true }
-    fn call_create_l64_after_gas() -> bool { false }
-    fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        &ETC_PRECOMPILEDS }
-}
-
-/// Homestead patch.
-pub struct HomesteadPatch<A: AccountPatch>(PhantomData<A>);
-pub type MainnetHomesteadPatch = HomesteadPatch<MainnetAccountPatch>;
-impl<A: AccountPatch> Patch for HomesteadPatch<A> {
-    type Account = A;
-
-    fn code_deposit_limit() -> Option<usize> { None }
-    fn callstack_limit() -> usize { 1024 }
-    fn gas_extcode() -> Gas { Gas::from(20usize) }
-    fn gas_balance() -> Gas { Gas::from(20usize) }
-    fn gas_sload() -> Gas { Gas::from(50usize) }
-    fn gas_suicide() -> Gas { Gas::from(0usize) }
-    fn gas_suicide_new_account() -> Gas { Gas::from(0usize) }
-    fn gas_call() -> Gas { Gas::from(40usize) }
-    fn gas_expbyte() -> Gas { Gas::from(10usize) }
-    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
-    fn force_code_deposit() -> bool { false }
-    fn has_delegate_call() -> bool { true }
-    fn has_static_call() -> bool { false }
-    fn has_revert() -> bool { false }
-    fn has_return_data() -> bool { false }
-    fn err_on_call_with_more_gas() -> bool { true }
-    fn call_create_l64_after_gas() -> bool { false }
-    fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        &ETC_PRECOMPILEDS }
-}
-
 /// Patch sepcific for the `jsontests` crate.
 pub struct VMTestPatch;
 impl Patch for VMTestPatch {
-    type Account = MainnetAccountPatch;
+    type Account = EmbeddedAccountPatch;
 
     fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 2 }
@@ -176,72 +118,13 @@ impl Patch for VMTestPatch {
     fn call_create_l64_after_gas() -> bool { false }
     fn memory_limit() -> usize { usize::max_value() }
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        &ETC_PRECOMPILEDS }
+        &EMBEDDED_PRECOMPILEDS }
 }
-
-/// EIP150 patch.
-pub struct EIP150Patch<A: AccountPatch>(PhantomData<A>);
-pub type MainnetEIP150Patch = EIP150Patch<MainnetAccountPatch>;
-impl<A: AccountPatch> Patch for EIP150Patch<A> {
-    type Account = A;
-
-    fn code_deposit_limit() -> Option<usize> { None }
-    fn callstack_limit() -> usize { 1024 }
-    fn gas_extcode() -> Gas { Gas::from(700usize) }
-    fn gas_balance() -> Gas { Gas::from(400usize) }
-    fn gas_sload() -> Gas { Gas::from(200usize) }
-    fn gas_suicide() -> Gas { Gas::from(5000usize) }
-    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
-    fn gas_call() -> Gas { Gas::from(700usize) }
-    fn gas_expbyte() -> Gas { Gas::from(10usize) }
-    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
-    fn force_code_deposit() -> bool { false }
-    fn has_delegate_call() -> bool { true }
-    fn has_static_call() -> bool { false }
-    fn has_revert() -> bool { false }
-    fn has_return_data() -> bool { false }
-    fn err_on_call_with_more_gas() -> bool { false }
-    fn call_create_l64_after_gas() -> bool { true }
-    fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        &ETC_PRECOMPILEDS }
-}
-
-/// EIP160 patch.
-pub struct EIP160Patch<A: AccountPatch>(PhantomData<A>);
-pub type MainnetEIP160Patch = EIP160Patch<MainnetAccountPatch>;
-impl<A: AccountPatch> Patch for EIP160Patch<A> {
-    type Account = A;
-
-    fn code_deposit_limit() -> Option<usize> { None }
-    fn callstack_limit() -> usize { 1024 }
-    fn gas_extcode() -> Gas { Gas::from(700usize) }
-    fn gas_balance() -> Gas { Gas::from(400usize) }
-    fn gas_sload() -> Gas { Gas::from(200usize) }
-    fn gas_suicide() -> Gas { Gas::from(5000usize) }
-    fn gas_suicide_new_account() -> Gas { Gas::from(25000usize) }
-    fn gas_call() -> Gas { Gas::from(700usize) }
-    fn gas_expbyte() -> Gas { Gas::from(50usize) }
-    fn gas_transaction_create() -> Gas { Gas::from(32000usize) }
-    fn force_code_deposit() -> bool { false }
-    fn has_delegate_call() -> bool { true }
-    fn has_static_call() -> bool { false }
-    fn has_revert() -> bool { false }
-    fn has_return_data() -> bool { false }
-    fn err_on_call_with_more_gas() -> bool { false }
-    fn call_create_l64_after_gas() -> bool { true }
-    fn memory_limit() -> usize { usize::max_value() }
-    fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)] {
-        &ETC_PRECOMPILEDS }
-}
-
-pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 0] = [];
 
 /// Embedded patch.
-pub struct EmbeddedPatch<A: AccountPatch>(PhantomData<A>);
-pub type MainnetEmbeddedPatch = EmbeddedPatch<MainnetAccountPatch>;
-impl<A: AccountPatch> Patch for EmbeddedPatch<A> {
-    type Account = A;
+pub struct EmbeddedPatch;
+impl Patch for EmbeddedPatch {
+    type Account = EmbeddedAccountPatch;
 
     fn code_deposit_limit() -> Option<usize> { None }
     fn callstack_limit() -> usize { 1024 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -561,7 +561,7 @@ mod tests {
             input: Rc::new(Vec::new()),
             nonce: U256::zero(),
         };
-        let mut vm = SeqTransactionVM::<MainnetEIP160Patch>::new(transaction, HeaderParams {
+        let mut vm = SeqTransactionVM::<EmbeddedPatch>::new(transaction, HeaderParams {
             beneficiary: Address::default(),
             timestamp: 0,
             number: U256::zero(),
@@ -598,7 +598,7 @@ mod tests {
             input: Rc::new(Vec::new()),
             nonce: U256::zero(),
         };
-        let mut vm = SeqTransactionVM::<MainnetEIP160Patch>::new(transaction, HeaderParams {
+        let mut vm = SeqTransactionVM::<EmbeddedPatch>::new(transaction, HeaderParams {
             beneficiary: Address::default(),
             timestamp: 0,
             number: U256::zero(),

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -20,3 +20,4 @@ serde_derive = "1.0"
 serde_json = "1.0"
 lazy_static = "0.2"
 etcommon-hexutil = "0.2"
+sputnikvm-network-classic = { path = "../network/classic" }

--- a/stateful/examples/parallel.rs
+++ b/stateful/examples/parallel.rs
@@ -4,12 +4,14 @@ extern crate hexutil;
 extern crate bigint;
 extern crate sputnikvm;
 extern crate sputnikvm_stateful;
+extern crate sputnikvm_network_classic;
 #[macro_use] extern crate lazy_static;
 
 use hexutil::*;
 use block::TransactionAction;
 use bigint::{Address, U256, Gas};
-use sputnikvm::{AccountChange, HeaderParams, SeqTransactionVM, VM, Storage, MainnetEIP160Patch, ValidTransaction};
+use sputnikvm::{AccountChange, HeaderParams, SeqTransactionVM, VM, Storage, ValidTransaction};
+use sputnikvm_network_classic::{MainnetEIP160Patch, EIP160Patch};
 use trie::MemoryDatabase;
 use sputnikvm_stateful::{MemoryStateful, LiteralAccount};
 use std::thread;

--- a/stateful/tests/genesis.rs
+++ b/stateful/tests/genesis.rs
@@ -5,6 +5,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
 extern crate sputnikvm;
+extern crate sputnikvm_network_classic;
 extern crate sputnikvm_stateful;
 extern crate block;
 extern crate trie;
@@ -14,7 +15,8 @@ extern crate bigint;
 
 use sha3::{Digest, Keccak256};
 use bigint::{H256, U256, Address, Gas};
-use sputnikvm::{ValidTransaction, Storage, AccountChange, VM, SeqTransactionVM, HeaderParams, MainnetEIP160Patch, EIP160Patch, VMStatus, AccountPatch};
+use sputnikvm::{ValidTransaction, Storage, AccountChange, VM, SeqTransactionVM, HeaderParams, VMStatus, AccountPatch};
+use sputnikvm_network_classic::{MainnetEIP160Patch, EIP160Patch};
 use sputnikvm_stateful::{MemoryStateful, LiteralAccount};
 use block::TransactionAction;
 use trie::{Database, MemoryDatabase};


### PR DESCRIPTION
Summary:
This moves Classic patches to a separate crate (`sputnikvm-network-classic`), and add additional patches for Foundation, Ellaism, Musicoin, Expanse, Ubiq.