### PR TITLE
Add context history hook in place of debugging variables

### DIFF
--- a/jsontests/src/lib.rs
+++ b/jsontests/src/lib.rs
@@ -10,6 +10,7 @@ pub use self::blockchain::{JSONBlock, create_block, create_context};
 use serde_json::Value;
 use std::str::FromStr;
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 use bigint::{Gas, M256, U256, H256, Address};
 use hexutil::*;
 use sputnikvm::errors::RequireError;
@@ -71,7 +72,7 @@ pub fn create_machine(v: &Value, block: &JSONBlock) -> SeqContextVM<VMTestPatch>
     SeqContextVM::<VMTestPatch>::new(transaction, block.block_header())
 }
 
-pub fn test_machine(v: &Value, machine: &SeqContextVM<VMTestPatch>, block: &JSONBlock, debug: bool) -> bool {
+pub fn test_machine(v: &Value, machine: &SeqContextVM<VMTestPatch>, block: &JSONBlock, history: &Vec<Context>, debug: bool) -> bool {
     let ref callcreates = v["callcreates"];
 
     if callcreates.as_array().is_some() {
@@ -89,14 +90,14 @@ pub fn test_machine(v: &Value, machine: &SeqContextVM<VMTestPatch>, block: &JSON
             let gas_limit = Gas::from_str(callcreate["gasLimit"].as_str().unwrap()).unwrap();
             let value = U256::from_str(callcreate["value"].as_str().unwrap()).unwrap();
 
-            if i >= machine.history().len() {
+            if i >= history.len() {
                 if debug {
                     print!("\n");
                     println!("Transaction check failed, expected more than {} items.", i);
                 }
                 return false;
             }
-            let ref transaction = machine.history()[i];
+            let ref transaction = history[i];
             if destination.is_some() {
                 if transaction.address != destination.unwrap() {
                     if debug {
@@ -253,7 +254,12 @@ fn is_ok(status: VMStatus) -> bool {
 
 pub fn test_transaction(name: &str, v: &Value, debug: bool) -> bool {
     let mut block = create_block(v);
+    let mut history: Arc<Mutex<Vec<Context>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut history_closure = history.clone();
     let mut machine = create_machine(v, &block);
+    machine.add_context_history_hook(move |context| {
+        history_closure.lock().unwrap().push(context.clone());
+    });
     fire_with_block(&mut machine, &block);
     apply_to_block(&machine, &mut block);
 
@@ -264,7 +270,7 @@ pub fn test_transaction(name: &str, v: &Value, debug: bool) -> bool {
 
     if out.is_some() {
         if is_ok(machine.status()) {
-            if test_machine(v, &machine, &block, debug) {
+            if test_machine(v, &machine, &block, &history.lock().unwrap(), debug) {
                 return true;
             } else {
                 return false;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -135,6 +135,9 @@ pub struct Runtime {
     pub blockhash_state: BlockhashState,
     /// Block header.
     pub block: HeaderParams,
+
+    /// Hooks for context history.
+    pub context_history_hooks: Vec<Box<Fn(&Context)>>,
 }
 
 impl Runtime {
@@ -144,7 +147,9 @@ impl Runtime {
 
     pub fn with_states(block: HeaderParams, blockhash_state: BlockhashState) -> Self {
         Runtime {
-            block, blockhash_state
+            block, blockhash_state,
+
+            context_history_hooks: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Summary:
In ContextVM, remove the history debug variable to avoid runtime overhead, and add `add_context_history_hook` where debuggers can implement the old behaviour by themselves. Fix
`jsontests` to use the new hook system when testing against context histories.