### PR TITLE
Documentation improvements and remove duplicate codes

### DIFF
--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/ethereumproject/sputnikvm"
 [dependencies]
 sputnikvm = { version = "0.9", path = "../.." }
 etcommon-bigint = { version = "0.2", default-features = false }
-bn = { git = "https://github.com/paritytech/bn" }
+bn-plus = { version = "0.4" }

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -171,6 +171,8 @@ pub enum AccountChange {
         /// Code associated with this account.
         code: Rc<Vec<u8>>
     },
+    /// The account should remain nonexist, or should be deleted if
+    /// exists.
     Nonexist(Address)
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ pub enum PreExecutionError {
 }
 
 #[derive(Debug, Clone)]
+/// Errors that can be written on chain.
 pub enum OnChainError {
     /// Stack is overflowed (pushed more than 1024 items to the
     /// stack).
@@ -61,6 +62,8 @@ impl From<OnChainError> for EvalError {
 }
 
 #[derive(Debug, Clone)]
+/// Errors when the VM detects that it does not support certain
+/// operations.
 pub enum NotSupportedError {
     /// The memory index is too large for the implementation of the VM to
     /// handle.
@@ -82,6 +85,8 @@ impl From<NotSupportedError> for EvalError {
 }
 
 #[derive(Debug, Clone)]
+/// Runtime error. Can either be an on-chain error or a not-supported
+/// error.
 pub enum RuntimeError {
     /// On chain error.
     OnChain(OnChainError),
@@ -101,8 +106,12 @@ impl From<RuntimeError> for EvalError {
 }
 
 #[derive(Debug, Clone)]
+/// Eval on-chain error. Can either be an on-chain error or a require
+/// error.
 pub enum EvalOnChainError {
+    /// On chain error.
     OnChain(OnChainError),
+    /// Require error for additional accounts.
     Require(RequireError),
 }
 
@@ -118,9 +127,13 @@ impl From<EvalOnChainError> for EvalError {
 }
 
 #[derive(Debug, Clone)]
+/// Eval error. On-chain error, not-supported error or require error.
 pub enum EvalError {
+    /// On chain error.
     OnChain(OnChainError),
+    /// Off chain error due to VM not supported.
     NotSupported(NotSupportedError),
+    /// Require error for additional accounts.
     Require(RequireError),
 }
 

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -118,7 +118,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Finalize a transaction. This should not be used when invoked
-    /// by an opcode.
+    /// by an opcode and should only be used in the top level.
     ///
     /// ### Panic
     /// Requires caller of the transaction to be committed.
@@ -166,6 +166,11 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         }
     }
 
+    /// Finalize a context execution. This should not be used when
+    /// invoked by an opcode and should only be used in the top level.
+    ///
+    /// ### Panic
+    /// Requires caller of the transaction to be committed.
     pub fn finalize_context(&mut self, fresh_account_state: &AccountState<P::Account>) {
         match self.status() {
             MachineStatus::ExitedOk => (),

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -141,10 +141,12 @@ pub struct Runtime {
 }
 
 impl Runtime {
+    /// Create a new VM runtime.
     pub fn new(block: HeaderParams) -> Self {
         Self::with_states(block, BlockhashState::default())
     }
 
+    /// Create the runtime with the given blockhash state.
     pub fn with_states(block: HeaderParams, blockhash_state: BlockhashState) -> Self {
         Runtime {
             block, blockhash_state,
@@ -171,6 +173,10 @@ pub enum MachineStatus {
     /// This runtime has exited with errors. Calling `step` on this
     /// runtime again would panic.
     ExitedErr(OnChainError),
+    /// This runtime has exited because it does not support certain
+    /// operations. Unlike `ExitedErr`, this is not on-chain, and if
+    /// it happens, client should either drop the transaction or panic
+    /// (because it rarely happens).
     ExitedNotSupported(NotSupportedError),
     /// This runtime requires execution of a sub runtime, which is a
     /// ContractCreation instruction.
@@ -298,6 +304,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         return false;
     }
 
+    /// Peek the next instruction.
     pub fn peek(&self) -> Option<Instruction> {
         let pc = PC::<P>::new(&self.state.context.code,
                               &self.state.valids, &self.state.position);
@@ -307,6 +314,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         }
     }
 
+    /// Peek the next opcode.
     pub fn peek_opcode(&self) -> Option<Opcode> {
         let pc = PC::<P>::new(&self.state.context.code,
                               &self.state.valids, &self.state.position);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 #![deny(unused_import_braces, unused_imports,
         unused_comparisons, unused_must_use,
         unused_variables, non_shorthand_field_patterns,
-        unreachable_code)]
+        unreachable_code, missing_docs)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
@@ -84,6 +84,11 @@ pub enum VMStatus {
     /// VM is stopped due to an error. The state of the VM is before
     /// the last failing instruction.
     ExitedErr(OnChainError),
+    /// VM is stopped because it does not support certain
+    /// operations. The client is expected to either drop the
+    /// transaction or panic. This rarely happens unless the executor
+    /// agrees upon on a really large number of gas limit, so it
+    /// usually can be safely ignored.
     ExitedNotSupported(NotSupportedError),
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -50,6 +50,7 @@ impl<P: Patch> Default for SeqMemory<P> {
 }
 
 impl<P: Patch> SeqMemory<P> {
+    /// Get the length of the current effective memory range.
     pub fn len(&self) -> usize {
         self.memory.len()
     }

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -87,6 +87,7 @@ pub trait Patch {
     fn precompileds() -> &'static [(Address, Option<&'static [u8]>, &'static Precompiled)];
 }
 
+/// Default precompiled collections.
 pub static EMBEDDED_PRECOMPILEDS: [(Address, Option<&'static [u8]>, &'static Precompiled); 4] = [
     (H160([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0x01]),
      None,

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -53,6 +53,7 @@ impl Precompiled for IDPrecompiled {
         Rc::new(data.into())
     }
 }
+/// Static value of ID precompiled contract.
 pub static ID_PRECOMPILED: IDPrecompiled = IDPrecompiled;
 
 /// RIP160 precompiled contract.
@@ -74,6 +75,7 @@ impl Precompiled for RIP160Precompiled {
         Rc::new(result.as_ref().into())
     }
 }
+/// Static value of RIP160 precompiled contract.
 pub static RIP160_PRECOMPILED: RIP160Precompiled = RIP160Precompiled;
 
 /// SHA256 precompiled contract.
@@ -96,6 +98,7 @@ impl Precompiled for SHA256Precompiled {
         Rc::new(result.as_ref().into())
     }
 }
+/// Static value of SHA256 precompiled contract.
 pub static SHA256_PRECOMPILED: SHA256Precompiled = SHA256Precompiled;
 
 /// ECREC precompiled contract.
@@ -130,6 +133,7 @@ impl Precompiled for ECRECPrecompiled {
         Err(RuntimeError::NotSupported(NotSupportedError::PrecompiledNotSupported))
     }
 }
+/// Static value of ECREC precompiled contract.
 pub static ECREC_PRECOMPILED: ECRECPrecompiled = ECRECPrecompiled;
 
 fn gas_div_ceil(a: Gas, b: Gas) -> Gas {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -38,6 +38,8 @@ macro_rules! system_address {
     }
 }
 
+#[derive(Debug, Clone)]
+/// Represents an untrusted Ethereum transaction.
 pub struct UntrustedTransaction {
     pub caller: AccountCommitment,
     pub gas_price: Gas,
@@ -48,6 +50,7 @@ pub struct UntrustedTransaction {
 }
 
 impl UntrustedTransaction {
+    /// Convert to a valid transaction.
     pub fn to_valid<P: Patch>(&self) -> Result<ValidTransaction, PreExecutionError> {
         let valid = {
             let (nonce, balance, address) = match self.caller.clone() {
@@ -90,6 +93,7 @@ impl UntrustedTransaction {
     }
 }
 
+#[derive(Debug, Clone)]
 /// Represents an Ethereum transaction.
 ///
 /// ## About SYSTEM transaction
@@ -104,8 +108,6 @@ impl UntrustedTransaction {
 /// Because the transaction reward is always zero, a SYSTEM
 /// transaction will also not invoke creation of the beneficiary
 /// address if it does not exist before.
-
-#[derive(Debug, Clone)]
 pub struct ValidTransaction {
     /// Caller of this transaction. If caller is None, then this is a
     /// SYSTEM transaction.
@@ -284,6 +286,8 @@ enum TransactionVMState<M, P: Patch> {
 pub struct TransactionVM<M, P: Patch>(TransactionVMState<M, P>);
 
 impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
+    /// Create a VM from an untrusted transaction. It can be any
+    /// transaction and the VM will return an error if it has errors.
     pub fn new_untrusted(transaction: UntrustedTransaction, block: HeaderParams) -> Result<Self, PreExecutionError> {
         let valid = transaction.to_valid::<P>()?;
         let mut vm = TransactionVM(TransactionVMState::Constructing {


### PR DESCRIPTION
This finalizes `v0.10.0`:

* Use a macro to implement PC and PCMut to remove duplicate codes.
* Throw on missing_docs for core crates and add more documentations.
* Depend on bn-plus for crate publishing.