### PR TITLE
WIP - rework using current Ethereum VMtests...

### DIFF
--- a/jsontests/res/VMTests/vmArithmeticTest/add0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/add0.json
@@ -1,0 +1,50 @@
+{
+    "add0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/add0Filler.json",
+            "sourceHash": "dcc7fc8aebdc2d7334440cfe6c63172941b4164c1ba8c32897318ca0cdfb7a1c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/add1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/add1.json
@@ -1,0 +1,50 @@
+{
+    "add1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/add1Filler.json",
+            "sourceHash": "f21647f7464e6af98c7a9817d45d0665345edc8837011bfbdd2190da3ac83d1c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60047fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60047fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x03"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60047fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/add2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/add2.json
@@ -1,0 +1,48 @@
+{
+    "add2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/add2Filler.json",
+            "sourceHash": "70cc0c9520ca96d910fafb84c8b9df26b72e98475e32a61d2dc85c8dc9c2b4b8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/add3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/add3.json
@@ -1,0 +1,48 @@
+{
+    "add3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/add3Filler.json",
+            "sourceHash": "105038289d098d6a996d371943b892f3027319743c8769f26e5e617cbe0387e2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000600001600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600001600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600001600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/add4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/add4.json
@@ -1,0 +1,48 @@
+{
+    "add4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/add4Filler.json",
+            "sourceHash": "0758cd23f1cf3cd7d81780fc3abfd6dd483584cc974d40e8d1825ffb2238cffe"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600101600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600101600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600101600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod0.json
@@ -1,0 +1,50 @@
+{
+    "addmod0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod0Filler.json",
+            "sourceHash": "69837588368b0147085975aff924957c968a252ad30938046ca6b578bc3728c3"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026002600108600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600108600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600108600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod1.json
@@ -1,0 +1,50 @@
+{
+    "addmod1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod1Filler.json",
+            "sourceHash": "8e0b69e7950cbfe076b88f60ab984eb43451ef2ffd82e057a493d40c63340e96"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026002600003600160000308600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013860",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600003600160000308600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600003600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow2.json
@@ -1,0 +1,48 @@
+{
+    "addmod1_overflow2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod1_overflow2Filler.json",
+            "sourceHash": "ea89bb1d2edf42a3679edc6e79a1547ab2acab88b65fdd898848f069d4668887"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056000600160000308600055",
+            "data": "0x",
+            "gas": "0x2710",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x136e",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056000600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056000600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow3.json
@@ -1,0 +1,50 @@
+{
+    "addmod1_overflow3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod1_overflow3Filler.json",
+            "sourceHash": "c6622fc4640ee14bc04fc25d6d8e1b8e9f276900cefab7731296e2d40e4e74de"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056001600160000308600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef406",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056001600160000308600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056001600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflow4.json
@@ -1,0 +1,50 @@
+{
+    "addmod1_overflow4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod1_overflow4Filler.json",
+            "sourceHash": "60b3af67e1525c925ad468a9c5879f3a1dd9264bd71599d14bb0fe5ee85baa32"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056002600160000308600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef406",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600160000308600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflowDiff.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod1_overflowDiff.json
@@ -1,0 +1,50 @@
+{
+    "addmod1_overflowDiff": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod1_overflowDiffFiller.json",
+            "sourceHash": "e481611b65bea729363ab4905b904b25dabf4e37b459275fadf20ec26c03a7e6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056002600003600160000308600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef400",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600003600160000308600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x04"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600003600160000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod2.json
@@ -1,0 +1,50 @@
+{
+    "addmod2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod2Filler.json",
+            "sourceHash": "9c69727304f62e9a9e68c0f26fdec5c71bca730c09fa3cec098fe6814ea868ed"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600660000308600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod2_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod2_0.json
@@ -1,0 +1,48 @@
+{
+    "addmod2_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod2_0Filler.json",
+            "sourceHash": "e3f2905fabd335c0e86de4d6f33bcd256da698a52a685e3951529da4d1571b4d"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600660000308600360056000030714600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172ea",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600360056000030714600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600360056000030714600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod2_1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod2_1.json
@@ -1,0 +1,50 @@
+{
+    "addmod2_1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod2_1Filler.json",
+            "sourceHash": "7df326e4ca2b1e49badec9487259198cd6190ac5620e9d7197dd4d357155a3ab"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600660000308600360056000030614600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013852",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600360056000030614600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600660000308600360056000030614600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod3.json
@@ -1,0 +1,50 @@
+{
+    "addmod3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod3Filler.json",
+            "sourceHash": "c24520291ed9c7c7764a3ddf54564cadbf705459bc4930e2bccab74056799631"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036000036001600408600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036000036001600408600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x05"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036000036001600408600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmod3_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmod3_0.json
@@ -1,0 +1,48 @@
+{
+    "addmod3_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmod3_0Filler.json",
+            "sourceHash": "fd0fb4ca3416d536afb39bdd1ff061d834d7b2c4089b544f0ba7eace18e2acb7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026003600003600160040814600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172f8",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026003600003600160040814600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026003600003600160040814600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmodBigIntCast.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmodBigIntCast.json
@@ -1,0 +1,50 @@
+{
+    "addmodBigIntCast": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmodBigIntCastFiller.json",
+            "sourceHash": "a38c1a69123e72b56d9cc442d5be6aa54f7f4cf9354f0160c461b1c61baede57"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600560017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff08600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero.json
@@ -1,0 +1,48 @@
+{
+    "addmodDivByZero": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmodDivByZeroFiller.json",
+            "sourceHash": "1cd414944cb3298349f3672c7e01b0cbf98de4a216b8385914b37eafb908aa89"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006001600408600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600408600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600408600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero1.json
@@ -1,0 +1,48 @@
+{
+    "addmodDivByZero1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmodDivByZero1Filler.json",
+            "sourceHash": "63f039bd579d518124284d302bfdb4b7cf6e669737b54aded9ed25fd9efc64ab"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006001600008600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600008600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600008600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero2.json
@@ -1,0 +1,48 @@
+{
+    "addmodDivByZero2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmodDivByZero2Filler.json",
+            "sourceHash": "f1ccd94023526e6d5eeaafaeb3bd90ac7c027fde926b25563345c9ab01f24286"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006000600108600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600108600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600108600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/addmodDivByZero3.json
@@ -1,0 +1,50 @@
+{
+    "addmodDivByZero3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/addmodDivByZero3Filler.json",
+            "sourceHash": "c23eb8b07209c00db096f72b7c47b647c2eba38d7876e524b80d4d06a8bacfe7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016000600060000803600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000600060000803600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000600060000803600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/arith1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/arith1.json
@@ -1,0 +1,48 @@
+{
+    "arith1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/arith1Filler.json",
+            "sourceHash": "8f3e7dc473f01ad6eb28485f6d16657a65de82e702d4a3be4cac3968b12b817c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600190016007026005016002900460049060016021900560150160030260059007600303600960110a60005260086000f3",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f41bf",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x0000000000000000",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600190016007026005016002900460049060016021900560150160030260059007600303600960110a60005260086000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600190016007026005016002900460049060016021900560150160030260059007600303600960110a60005260086000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/div1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/div1.json
@@ -1,0 +1,48 @@
+{
+    "div1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/div1Filler.json",
+            "sourceHash": "f99cfceb609ecc9e592633614ecc763e1ca15bf0f3fbfb3e9a52131b81432ad4"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60027ffedcba9876543210fedcba9876543210fedcba9876543210fedcba98765432100460005260206000f3",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x018686",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x7f6e5d4c3b2a19087f6e5d4c3b2a19087f6e5d4c3b2a19087f6e5d4c3b2a1908",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60027ffedcba9876543210fedcba9876543210fedcba9876543210fedcba98765432100460005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60027ffedcba9876543210fedcba9876543210fedcba9876543210fedcba98765432100460005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divBoostBug.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divBoostBug.json
@@ -1,0 +1,50 @@
+{
+    "divBoostBug": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divBoostBugFiller.json",
+            "sourceHash": "b3c8814728f78142bae06edbd7083f7823401350927f18d772d4c042463059f8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f01dae6076b981dae6076b981dae6076b981dae6076b981dae6076b981dae60777fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffba04600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f01dae6076b981dae6076b981dae6076b981dae6076b981dae6076b981dae60777fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffba04600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x89"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f01dae6076b981dae6076b981dae6076b981dae6076b981dae6076b981dae60777fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffba04600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByNonZero0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByNonZero0.json
@@ -1,0 +1,50 @@
+{
+    "divByNonZero0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByNonZero0Filler.json",
+            "sourceHash": "d181ed91b0939a2527e2a4fd0629de1c66407a57935fc653d03c2eb946c41491"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6002600504600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6002600504600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6002600504600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByNonZero1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByNonZero1.json
@@ -1,0 +1,48 @@
+{
+    "divByNonZero1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByNonZero1Filler.json",
+            "sourceHash": "64101d7909679fa39a402c3aaf5e363a0129c8cd83e2d754effbe2864b680457"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6018601704600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6018601704600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6018601704600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByNonZero2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByNonZero2.json
@@ -1,0 +1,48 @@
+{
+    "divByNonZero2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByNonZero2Filler.json",
+            "sourceHash": "69cda4579ec75d9e597c76a012dedd2e550ca3a9a562932e403a67c0889b6380"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6018600004600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6018600004600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6018600004600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByNonZero3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByNonZero3.json
@@ -1,0 +1,50 @@
+{
+    "divByNonZero3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByNonZero3Filler.json",
+            "sourceHash": "ad37d228f0e5cc0073ed20dcf7395d612e1e12a073c1c3c18a0ceee814395b75"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600104600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600104600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600104600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByZero.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByZero.json
@@ -1,0 +1,48 @@
+{
+    "divByZero": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByZeroFiller.json",
+            "sourceHash": "0379670d4f721590eeb930531b621d2403d012cd378806e54c282313fd73f0f0"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000600204600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600204600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600204600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/divByZero_2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/divByZero_2.json
@@ -1,0 +1,50 @@
+{
+    "divByZero_2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/divByZero_2Filler.json",
+            "sourceHash": "7931861f0598f5b3911c92dba838659607254e549d5e8451d71bc69d047cebc2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60076000600d0401600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076000600d0401600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x07"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076000600d0401600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp0.json
@@ -1,0 +1,50 @@
+{
+    "exp0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp0Filler.json",
+            "sourceHash": "972ed941f04945ffe82066f3e35ac6187cf6411a6e5361540a67dc5a94d4ea07"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600260020a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013863",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600260020a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x04"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600260020a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp1.json
@@ -1,0 +1,50 @@
+{
+    "exp1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp1Filler.json",
+            "sourceHash": "d5ef9a5cada0a6a7fb1fab06d7b1a09efe7f130f15fc1c8ea2f7d0b227acadb2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01372d",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp2.json
@@ -1,0 +1,50 @@
+{
+    "exp2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp2Filler.json",
+            "sourceHash": "8305010503c8432e2e59f017e616fdda7fbedbe832b75cf485c5c78eb47e591a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x637fffffff637fffffff0a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013845",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x637fffffff637fffffff0a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xbc8cccccccc888888880000000aaaaaab00000000fffffffffffffff7fffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x637fffffff637fffffff0a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp3.json
@@ -1,0 +1,48 @@
+{
+    "exp3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp3Filler.json",
+            "sourceHash": "5b5083de3c559be83b4acd451637c1515a1e2f17881207c4c6f1b96ad87fd919"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x637fffffff60000a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172dd",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x637fffffff60000a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x637fffffff60000a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp4.json
@@ -1,0 +1,50 @@
+{
+    "exp4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp4Filler.json",
+            "sourceHash": "cd45ef70914f24f4d701e7fb8602cfe8ee91f474cdd6405d04fe96447d8f7053"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000637fffffff0a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386d",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000637fffffff0a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000637fffffff0a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp5.json
@@ -1,0 +1,50 @@
+{
+    "exp5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp5Filler.json",
+            "sourceHash": "318ed8bab4309bfe3524b15cbf8d41c00ce6f0caaa795b3c18e63a65b7e36e25"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016101010a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013863",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101010a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101010a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp6.json
@@ -1,0 +1,50 @@
+{
+    "exp6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp6Filler.json",
+            "sourceHash": "5b7c62113f0d591dbb9e75c8d51a0ce3e2288d431080a8265b2573371deb1edc"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x61010160010a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013859",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010160010a600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010160010a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/exp7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/exp7.json
@@ -1,0 +1,48 @@
+{
+    "exp7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/exp7Filler.json",
+            "sourceHash": "d1e5fa546ea20fce99bb003a4cdbd043c94289ad308e449c072729f43e0a44df"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x61010160020a600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172f1",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010160020a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010160020a600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_0.json
@@ -1,0 +1,58 @@
+{
+    "expPowerOf256Of256_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_0Filler.json",
+            "sourceHash": "2c087aea8c4b5c91100e892acf0e8b2bc1bc29d9f936f0d55603759df8783de7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006101000a6101000a600055600060ff0a6101000a60015560006101010a6101000a60025560006101000a60ff0a600355600060ff0a60ff0a60045560006101010a60ff0a60055560006101000a6101010a600655600060ff0a6101010a60075560006101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0c81a6",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006101000a6101000a600055600060ff0a6101000a60015560006101010a6101000a60025560006101000a60ff0a600355600060ff0a60ff0a60045560006101010a60ff0a60055560006101000a6101010a600655600060ff0a6101010a60075560006101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100",
+                    "0x01": "0x0100",
+                    "0x02": "0x0100",
+                    "0x03": "0xff",
+                    "0x04": "0xff",
+                    "0x05": "0xff",
+                    "0x06": "0x0101",
+                    "0x07": "0x0101",
+                    "0x08": "0x0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006101000a6101000a600055600060ff0a6101000a60015560006101010a6101000a60025560006101000a60ff0a600355600060ff0a60ff0a60045560006101010a60ff0a60055560006101000a6101010a600655600060ff0a6101010a60075560006101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_1.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_1Filler.json",
+            "sourceHash": "faec3c0e24c533aecb3e826308adb1e22fb205308a12cd31a271fee63d54a838"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016101000a6101000a600055600160ff0a6101000a60015560016101010a6101000a60025560016101000a60ff0a600355600160ff0a60ff0a60045560016101010a60ff0a60055560016101000a6101010a600655600160ff0a6101010a60075560016101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d30d8",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101000a6101000a600055600160ff0a6101000a60015560016101010a6101000a60025560016101000a60ff0a600355600160ff0a60ff0a60045560016101010a60ff0a60055560016101000a6101010a600655600160ff0a6101010a60075560016101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x06c3acd330b959ad6efabce6d2d2125e73a88a65a9880d203dddf5957f7f0001",
+                    "0x04": "0x8f965a06da0ac41dcb3a34f1d8ab7d8fee620a94faa42c395997756b007ffeff",
+                    "0x05": "0xbce9265d88a053c18bc229ebff404c1534e1db43de85131da0179fe9ff8100ff",
+                    "0x06": "0x02b5e9d7a094c19f5ebdd4f2e618f859ed15e4f1f0351f286bf849eb7f810001",
+                    "0x07": "0xc73b7a6f68385c653a24993bb72eea0e4ba17470816ec658cf9c5bedfd81ff01",
+                    "0x08": "0xb89fc178355660fe1c92c7d8ff11524702fad6e2255447946442356b00810101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101000a6101000a600055600160ff0a6101000a60015560016101010a6101000a60025560016101000a60ff0a600355600160ff0a60ff0a60045560016101010a60ff0a60055560016101000a6101010a600655600160ff0a6101010a60075560016101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_10.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_10.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_10": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_10Filler.json",
+            "sourceHash": "168f4ca57a54e23f15c08d7e90f45fb7c99363fecdd085db589c29356ee134a2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600a6101000a6101000a600055600a60ff0a6101000a600155600a6101010a6101000a600255600a6101000a60ff0a600355600a60ff0a60ff0a600455600a6101010a60ff0a600555600a6101000a6101010a600655600a60ff0a6101010a600755600a6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2dae",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600a6101000a6101000a600055600a60ff0a6101000a600155600a6101010a6101000a600255600a6101000a60ff0a600355600a60ff0a60ff0a600455600a6101010a60ff0a600555600a6101000a6101010a600655600a60ff0a6101010a600755600a6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xfe0f60957dc223578a0298879ec55c33085514ff7f0000000000000000000001",
+                    "0x04": "0xc1ea45f348b5d351c4d8fe5c77da979cadc33d866acc42e981278896b1f600ff",
+                    "0x05": "0x56ddb29bca94fb986ac0a40188b3b53f3216b3559bd8324a77ea8bd8a80a00ff",
+                    "0x06": "0x2d49ff6b0bbe177ae9317000b68fb921f7aa6aff810000000000000000000001",
+                    "0x07": "0x185fa9eab94cfe3016b69657e83b23fd24cc6960218254231c3db627a7f60101",
+                    "0x08": "0xa7a0223829f26d6c635368034320563df4aa5eb62efc87a42bb35f69b20a0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600a6101000a6101000a600055600a60ff0a6101000a600155600a6101010a6101000a600255600a6101000a60ff0a600355600a60ff0a60ff0a600455600a6101010a60ff0a600555600a6101000a6101010a600655600a60ff0a6101010a600755600a6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_11.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_11.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_11": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_11Filler.json",
+            "sourceHash": "9d7592fc1201b621168d87312f71b4400e9a4d4a398c82d8d7017de394278a57"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600b6101000a6101000a600055600b60ff0a6101000a600155600b6101010a6101000a600255600b6101000a60ff0a600355600b60ff0a60ff0a600455600b6101010a60ff0a600555600b6101000a6101010a600655600b60ff0a6101010a600755600b6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2d54",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600b6101000a6101000a600055600b60ff0a6101000a600155600b6101010a6101000a600255600b6101000a60ff0a600355600b60ff0a60ff0a600455600b6101010a60ff0a600555600b6101000a6101010a600655600b60ff0a6101010a600755600b6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xe1440264b8ee0cea0218879ec55c33085514ff7f000000000000000000000001",
+                    "0x04": "0x29575fdce377b23043e489e358581474bc863187fa85f9945473a2be5889feff",
+                    "0x05": "0x3df8c030ec521fb109c4d887dbbc14c7c9c9921b27058e3503971b60b18b00ff",
+                    "0x06": "0x67799740340daf4a30f000b68fb921f7aa6aff81000000000000000000000001",
+                    "0x07": "0x540a4e4635b40585e09ff10b63ffe310dd717fca5c0a51570091e25e378bff01",
+                    "0x08": "0xdbbaef5c49ffee61b08cde6ebc8dba6e9a62d56c2355d1980cb9e790bc8b0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600b6101000a6101000a600055600b60ff0a6101000a600155600b6101010a6101000a600255600b6101000a60ff0a600355600b60ff0a60ff0a600455600b6101010a60ff0a600555600b6101000a6101010a600655600b60ff0a6101010a600755600b6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_12.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_12.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_12": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_12Filler.json",
+            "sourceHash": "e3adac67619734e408082b0ae9173d9abd6d11564b5001297a4ebc00f2ccb4f7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600c6101000a6101000a600055600c60ff0a6101000a600155600c6101010a6101000a600255600c6101000a60ff0a600355600c60ff0a60ff0a600455600c6101010a60ff0a600555600c6101000a6101010a600655600c60ff0a6101010a600755600c6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2cfa",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600c6101000a6101000a600055600c60ff0a6101000a600155600c6101010a6101000a600255600c6101000a60ff0a600355600c60ff0a60ff0a600455600c6101010a60ff0a600555600c6101000a6101010a600655600c60ff0a6101010a600755600c6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xb0e95b83a36ce98218879ec55c33085514ff7f00000000000000000000000001",
+                    "0x04": "0xc482ab56ec19186dc48c88f30861a850b2253b1ea6dc021589e569bd47f400ff",
+                    "0x05": "0xcf45c7f9af4bbe4a83055b55b97777ad5e0a3f08b129c9ae208c5d713c0c00ff",
+                    "0x06": "0xa5cbb62a421049b0f000b68fb921f7aa6aff8100000000000000000000000001",
+                    "0x07": "0x3bde6ca66dffe1bf5d727c3edea74c7a4af43b3912e6256d37705c8f3bf40101",
+                    "0x08": "0x3f49a1e40c5213aa4ffed57eb4c1ad2d181b2aaa289e9d59c2256c43480c0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600c6101000a6101000a600055600c60ff0a6101000a600155600c6101010a6101000a600255600c6101000a60ff0a600355600c60ff0a60ff0a600455600c6101010a60ff0a600555600c6101000a6101010a600655600c60ff0a6101010a600755600c6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_13.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_13.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_13": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_13Filler.json",
+            "sourceHash": "c43c7b1e9b3eb12a8de5db33e61f4ef7baac02a5c7850bda31a68f4fde9549bf"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600d6101000a6101000a600055600d60ff0a6101000a600155600d6101010a6101000a600255600d6101000a60ff0a600355600d60ff0a60ff0a600455600d6101010a60ff0a600555600d6101000a6101010a600655600d60ff0a6101010a600755600d6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2ca0",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d6101000a6101000a600055600d60ff0a6101000a600155600d6101010a6101000a600255600d6101000a60ff0a600355600d60ff0a60ff0a600455600d6101010a60ff0a600555600d6101000a6101010a600655600d60ff0a6101010a600755600d6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xe02639036c698218879ec55c33085514ff7f0000000000000000000000000001",
+                    "0x04": "0x8be664bde946d939ce551b948b503787942d2a7734509288c1b62fd5c48bfeff",
+                    "0x05": "0xa923a28e7a75aef26c51580ffc686879e4a0b404b089bdbcd751d88b478d00ff",
+                    "0x06": "0x41ac5ea30fc9b0f000b68fb921f7aa6aff810000000000000000000000000001",
+                    "0x07": "0x0daa3a177ec975cb69bb4acf4a6e1be7bcc1ad33d1ffad97510f9fea9d8dff01",
+                    "0x08": "0x19e6822beb889be28310060f4fb9741bfd50a31fa81ec65de21f7b02548d0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d6101000a6101000a600055600d60ff0a6101000a600155600d6101010a6101000a600255600d6101000a60ff0a600355600d60ff0a60ff0a600455600d6101010a60ff0a600555600d6101000a6101010a600655600d60ff0a6101010a600755600d6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_14.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_14.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_14": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_14Filler.json",
+            "sourceHash": "27819e7b9b80ae0beb2297682b079269195974c9455de1eed3dca1034cba0048"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600e6101000a6101000a600055600e60ff0a6101000a600155600e6101010a6101000a600255600e6101000a60ff0a600355600e60ff0a60ff0a600455600e6101010a60ff0a600555600e6101000a6101010a600655600e60ff0a6101010a600755600e6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2c46",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600e6101000a6101000a600055600e60ff0a6101000a600155600e6101010a6101000a600255600e6101000a60ff0a600355600e60ff0a60ff0a600455600e6101010a60ff0a600555600e6101000a6101010a600655600e60ff0a6101010a600755600e6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xdb9902ec698218879ec55c33085514ff7f000000000000000000000000000001",
+                    "0x04": "0x83fab06c6c8fef761ebbb9534c06ac2a9d61820623008069062ff3b1e1f200ff",
+                    "0x05": "0x3f791dd183ed5b963bd86e0dba1a9dd5b8ceeb078f15c73062f1942fd40e00ff",
+                    "0x06": "0xe0bfa28fc9b0f000b68fb921f7aa6aff81000000000000000000000000000001",
+                    "0x07": "0x8133b760dfae27560eb490f235ddfa301f058dee4f01f3fe4b3567d0d3f20101",
+                    "0x08": "0xcd4cd0124e983af71620fb5f98275965c6a8bebc4b8adc288b63224ee20e0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600e6101000a6101000a600055600e60ff0a6101000a600155600e6101010a6101000a600255600e6101000a60ff0a600355600e60ff0a60ff0a600455600e6101010a60ff0a600555600e6101000a6101010a600655600e60ff0a6101010a600755600e6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_15.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_15.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_15": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_15Filler.json",
+            "sourceHash": "1a0490aa7bc91a8a40d9acac6288c71ffff4991b118b2f23b5965e94123bd705"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600f6101000a6101000a600055600f60ff0a6101000a600155600f6101010a6101000a600255600f6101000a60ff0a600355600f60ff0a60ff0a600455600f6101010a60ff0a600555600f6101000a6101010a600655600f60ff0a6101010a600755600f6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2bec",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600f6101000a6101000a600055600f60ff0a6101000a600155600f6101010a6101000a600255600f6101000a60ff0a600355600f60ff0a60ff0a600455600f6101010a60ff0a600555600f6101000a6101010a600655600f60ff0a6101010a600755600f6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x9882ec698218879ec55c33085514ff7f00000000000000000000000000000001",
+                    "0x04": "0x75c4915e18b96704209738f5ca765568bb4dc4113d56683977825a132c8dfeff",
+                    "0x05": "0x5c76839bf5a80b1da705dbdf43e4dd6770cd7501af11ff2dab7918dfe18f00ff",
+                    "0x06": "0xbf228fc9b0f000b68fb921f7aa6aff8100000000000000000000000000000001",
+                    "0x07": "0xc6a29131e7594004bc2aa79f0d2c402a1409c57c77d284c14b1a3ab0ff8fff01",
+                    "0x08": "0xe6b3e5cf6ec90e532fef7d08455ebf92a03e9e3f6e224ea0febdf1a9f08f0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600f6101000a6101000a600055600f60ff0a6101000a600155600f6101010a6101000a600255600f6101000a60ff0a600355600f60ff0a60ff0a600455600f6101010a60ff0a600555600f6101000a6101010a600655600f60ff0a6101010a600755600f6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_16.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_16.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_16": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_16Filler.json",
+            "sourceHash": "30f6e889411698eed13e2a040a2f41fe3c1fd4b1833cc785be622659996ad479"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60106101000a6101000a600055601060ff0a6101000a60015560106101010a6101000a60025560106101000a60ff0a600355601060ff0a60ff0a60045560106101010a60ff0a60055560106101000a6101010a600655601060ff0a6101010a60075560106101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2b92",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60106101000a6101000a600055601060ff0a6101000a60015560106101010a6101000a60025560106101000a60ff0a600355601060ff0a60ff0a60045560106101010a60ff0a60055560106101000a6101010a600655601060ff0a6101010a60075560106101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x82ec698218879ec55c33085514ff7f0000000000000000000000000000000001",
+                    "0x04": "0x3122f4bcdf6dd8b265cd18eb6af28c879aed44a35e0bf59273e39e6c7ff000ff",
+                    "0x05": "0x6a2b3bc87a02c29b9d27757df43047ecd0f15485270fca27417a701c701000ff",
+                    "0x06": "0x228fc9b0f000b68fb921f7aa6aff810000000000000000000000000000000001",
+                    "0x07": "0x88e1259502eef93d46060aacc9e2ff506c734dade0b6714ab12d17e46ff00101",
+                    "0x08": "0x4a103813c12c12169b218296bb0a9eae80cf8d2b158aa70eb990f99480100101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60106101000a6101000a600055601060ff0a6101000a60015560106101010a6101000a60025560106101000a60ff0a600355601060ff0a60ff0a60045560106101010a60ff0a60055560106101000a6101010a600655601060ff0a6101010a60075560106101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_17.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_17.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_17": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_17Filler.json",
+            "sourceHash": "1309371fad3cf12b98eb82958d017baef248f2efbffc7dbf8ab07a8efda75bee"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60116101000a6101000a600055601160ff0a6101000a60015560116101010a6101000a60025560116101000a60ff0a600355601160ff0a60ff0a60045560116101010a60ff0a60055560116101000a6101010a600655601160ff0a6101010a60075560116101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2b38",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60116101000a6101000a600055601160ff0a6101000a60015560116101010a6101000a60025560116101000a60ff0a600355601160ff0a60ff0a60045560116101010a60ff0a60055560116101000a6101010a600655601160ff0a6101010a60075560116101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xec698218879ec55c33085514ff7f000000000000000000000000000000000001",
+                    "0x04": "0x722ad218eb1995a2d257c4c06d8de993c203cfc8e3512df7d633e17e908ffeff",
+                    "0x05": "0x8ac9b5ec08d74612cb29f941481d274b51721af2296207c0da8d24667f9100ff",
+                    "0x06": "0x8fc9b0f000b68fb921f7aa6aff81000000000000000000000000000000000001",
+                    "0x07": "0x81d5ff63680841482299f3eab616446dcd336f537c0c565aa4112ab95d91ff01",
+                    "0x08": "0x9c6ca90dac4e97dea02ac969e8649ee9e6232e0c3f4797411151cb8f90910101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60116101000a6101000a600055601160ff0a6101000a60015560116101010a6101000a60025560116101000a60ff0a600355601160ff0a60ff0a60045560116101010a60ff0a60055560116101000a6101010a600655601160ff0a6101010a60075560116101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_18.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_18.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_18": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_18Filler.json",
+            "sourceHash": "a9a6c3dd976cca27cae0e2ebbf4bacf63b602384e8272cf61002445ebff136f5"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60126101000a6101000a600055601260ff0a6101000a60015560126101010a6101000a60025560126101000a60ff0a600355601260ff0a60ff0a60045560126101010a60ff0a60055560126101000a6101010a600655601260ff0a6101010a60075560126101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2ade",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60126101000a6101000a600055601260ff0a6101000a60015560126101010a6101000a60025560126101000a60ff0a600355601260ff0a60ff0a60045560126101010a60ff0a60055560126101000a6101010a600655601260ff0a6101010a60075560126101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x698218879ec55c33085514ff7f00000000000000000000000000000000000001",
+                    "0x04": "0x8a2cbd9f40794e2205b13306f2aa0a43c60823c64b95d8601fa4f1e521ee00ff",
+                    "0x05": "0xc1b5a1e3a81da51b10d84e880f0113ff67b863ddad3faf1f4ecf413f101200ff",
+                    "0x06": "0xc9b0f000b68fb921f7aa6aff8100000000000000000000000000000000000001",
+                    "0x07": "0x410be68e49452a1fbcd863bf6e8d637f8eae4979c34c88d552afbcc20fee0101",
+                    "0x08": "0xf540cb714754b5b1eb0373833833bd7fb0ee925ce8b92962500b7a1c22120101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60126101000a6101000a600055601260ff0a6101000a60015560126101010a6101000a60025560126101000a60ff0a600355601260ff0a60ff0a60045560126101010a60ff0a60055560126101000a6101010a600655601260ff0a6101010a60075560126101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_19.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_19.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_19": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_19Filler.json",
+            "sourceHash": "d0df2aa79ef6a5d1b803fb005e73447953da7171b4e947fa2936be3f148864f2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60136101000a6101000a600055601360ff0a6101000a60015560136101010a6101000a60025560136101000a60ff0a600355601360ff0a60ff0a60045560136101010a60ff0a60055560136101000a6101010a600655601360ff0a6101010a60075560136101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2a84",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60136101000a6101000a600055601360ff0a6101000a60015560136101010a6101000a60025560136101000a60ff0a600355601360ff0a60ff0a60045560136101010a60ff0a60055560136101000a6101010a600655601360ff0a6101010a60075560136101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x8218879ec55c33085514ff7f0000000000000000000000000000000000000001",
+                    "0x04": "0xb795ad7ac24cfbb7435cf53bd3584f3d4b2709935635c3ceb66e761ff091feff",
+                    "0x05": "0x1f0bb7be91a0ccd0cca93d75cf03de3e6b56fe8f1c54242617665327219300ff",
+                    "0x06": "0xb0f000b68fb921f7aa6aff810000000000000000000000000000000000000001",
+                    "0x07": "0xad571756ecbff1bfdef064861e5e92c5d897a9cc380e54bdbaabd80bb793ff01",
+                    "0x08": "0xd8b5b531989e689f700dcdb43ab90e79a49dfbbb5a13dbf751df98bb34930101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60136101000a6101000a600055601360ff0a6101000a60015560136101010a6101000a60025560136101000a60ff0a600355601360ff0a60ff0a60045560136101010a60ff0a60055560136101000a6101010a600655601360ff0a6101010a60075560136101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_2.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_2Filler.json",
+            "sourceHash": "398865268521f09f1e1d133600bd52ad4130e52f6846fc3c4b8e03b862e86f7e"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026101000a6101000a600055600260ff0a6101000a60015560026101010a6101000a60025560026101000a60ff0a600355600260ff0a60ff0a60045560026101010a60ff0a60055560026101000a6101010a600655600260ff0a6101010a60075560026101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d307e",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026101000a6101000a600055600260ff0a6101000a60015560026101010a6101000a60025560026101000a60ff0a600355600260ff0a60ff0a60045560026101010a60ff0a60055560026101000a6101010a600655600260ff0a6101010a60075560026101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x4ee4ceeaac565c81f55a87c43f82f7c889ef4fc7c679671e28d594ff7f000001",
+                    "0x04": "0x82f46a1b4e34d66712910615d2571d75606ceac51fa8ca8c58cf6ca881fe00ff",
+                    "0x05": "0x81c9fcefa5de158ae2007f25d35c0d11cd735342a48905955a5a6852800200ff",
+                    "0x06": "0x666ac362902470ed850709e2a29969d10cba09debc03c38d172aeaff81000001",
+                    "0x07": "0xeb30a3c678a01bde914548f98f3366dc0ffe9f85384ebf1111d03dad7ffe0101",
+                    "0x08": "0x72d0a7939b6303ce1d46e6e3f1b8be303bfdb2b00f41ad8076b0975782020101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026101000a6101000a600055600260ff0a6101000a60015560026101010a6101000a60025560026101000a60ff0a600355600260ff0a60ff0a60045560026101010a60ff0a60055560026101000a6101010a600655600260ff0a6101010a60075560026101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_20.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_20.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_20": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_20Filler.json",
+            "sourceHash": "80743f5e1e6a740339eec0441550741acc89ab879f198d7cc6d3905da24b2f41"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60146101000a6101000a600055601460ff0a6101000a60015560146101010a6101000a60025560146101000a60ff0a600355601460ff0a60ff0a60045560146101010a60ff0a60055560146101000a6101010a600655601460ff0a6101010a60075560146101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2a2a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60146101000a6101000a600055601460ff0a6101000a60015560146101010a6101000a60025560146101000a60ff0a600355601460ff0a60ff0a60045560146101010a60ff0a60055560146101000a6101010a600655601460ff0a6101010a60075560146101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x18879ec55c33085514ff7f000000000000000000000000000000000000000001",
+                    "0x04": "0x67e4797dc21f02ce4a7c52218c7dbea5d212e6c244e24f0ba4c08613c7ec00ff",
+                    "0x05": "0xa1ce1a085f258785846939cc1d2e8725ac94ad4dff8913234e00679fb41400ff",
+                    "0x06": "0xf000b68fb921f7aa6aff81000000000000000000000000000000000000000001",
+                    "0x07": "0xcce501857a1cb45473915a28082af950e0f78f7e2de68ce748adb661b3ec0101",
+                    "0x08": "0x3b2e28d274a16c08b58a23bad63bba6d7b09685769d1f68ca3873bedc8140101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60146101000a6101000a600055601460ff0a6101000a60015560146101010a6101000a60025560146101000a60ff0a600355601460ff0a60ff0a60045560146101010a60ff0a60055560146101000a6101010a600655601460ff0a6101010a60075560146101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_21.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_21.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_21": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_21Filler.json",
+            "sourceHash": "3e2c55bdd8e992c6c9db6910a82b34b8d2fd674a2e5d78d7411a8e35ffa7f093"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60156101000a6101000a600055601560ff0a6101000a60015560156101010a6101000a60025560156101000a60ff0a600355601560ff0a60ff0a60045560156101010a60ff0a60055560156101000a6101010a600655601560ff0a6101010a60075560156101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d29d0",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60156101000a6101000a600055601560ff0a6101000a60015560156101010a6101000a60025560156101000a60ff0a600355601560ff0a60ff0a60045560156101010a60ff0a60055560156101000a6101010a600655601560ff0a6101010a60075560156101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x879ec55c33085514ff7f00000000000000000000000000000000000000000001",
+                    "0x04": "0x7fd07055ff50cdfe4b4bd9a15133d72d3607d92eb7ac81bac93db7ff4c93feff",
+                    "0x05": "0x665ac5c769e87f61d5993abc26522fbfca2734d76a63216b2d550d29c79500ff",
+                    "0x06": "0xb68fb921f7aa6aff8100000000000000000000000000000000000000000001",
+                    "0x07": "0x1c93db67c9884bc694686d69a25a5d7ed089841d5ce147fdd7199ab00d95ff01",
+                    "0x08": "0x485053d8ff66be52036597520344fac87b6a305426a9e49221d3f934dc950101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60156101000a6101000a600055601560ff0a6101000a60015560156101010a6101000a60025560156101000a60ff0a600355601560ff0a60ff0a60045560156101010a60ff0a60055560156101000a6101010a600655601560ff0a6101010a60075560156101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_22.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_22.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_22": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_22Filler.json",
+            "sourceHash": "be37c9aac4e5399b3fe75515480c2cd65a9baf138655dd21f5a28ed9d55cb611"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60166101000a6101000a600055601660ff0a6101000a60015560166101010a6101000a60025560166101000a60ff0a600355601660ff0a60ff0a60045560166101010a60ff0a60055560166101000a6101010a600655601660ff0a6101010a60075560166101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2976",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60166101000a6101000a600055601660ff0a6101000a60015560166101010a6101000a60025560166101000a60ff0a600355601660ff0a60ff0a60045560166101010a60ff0a60055560166101000a6101010a600655601660ff0a6101010a60075560166101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x9ec55c33085514ff7f0000000000000000000000000000000000000000000001",
+                    "0x04": "0xec447e662ac08957d7e290a421dbf54c0aaf43aadc9cc465ad0b02f071ea00ff",
+                    "0x05": "0xdc9178d3bab470096f01477c859b5f4173986640b659426412a653465c1600ff",
+                    "0x06": "0xb68fb921f7aa6aff810000000000000000000000000000000000000000000001",
+                    "0x07": "0xdcf0a770777610503596ae0311af46c171151ed45107d7e7bb8f74bb5bea0101",
+                    "0x08": "0x4d65773387993928c95c861274232d3fb6f6b7fe1b22e4e61a30e71172160101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60166101000a6101000a600055601660ff0a6101000a60015560166101010a6101000a60025560166101000a60ff0a600355601660ff0a60ff0a60045560166101010a60ff0a60055560166101000a6101010a600655601660ff0a6101010a60075560166101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_23.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_23.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_23": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_23Filler.json",
+            "sourceHash": "73a851bb2f2033ee7a403b3ff65a627695c6eae37b1ab2a79b96533fad5fd14e"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60176101000a6101000a600055601760ff0a6101000a60015560176101010a6101000a60025560176101000a60ff0a600355601760ff0a60ff0a60045560176101010a60ff0a60055560176101000a6101010a600655601760ff0a6101010a60075560176101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d291c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60176101000a6101000a600055601760ff0a6101000a60015560176101010a6101000a60025560176101000a60ff0a600355601760ff0a60ff0a60045560176101010a60ff0a60055560176101000a6101010a600655601760ff0a6101010a60075560176101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xc55c33085514ff7f000000000000000000000000000000000000000000000001",
+                    "0x04": "0x537ca0f03f974303005f1e6693b55b72315a166841732e42b8353724a495feff",
+                    "0x05": "0x86418797ec60058de6cca47dfdbee79923ac49d7801e01840041ca76719700ff",
+                    "0x06": "0x8fb921f7aa6aff81000000000000000000000000000000000000000000000001",
+                    "0x07": "0x56a55341ab8d4318f1cfb55d5f21e2ba35d7e070a72bac6b2b21baae5f97ff01",
+                    "0x08": "0x55ddd0ec77909de6d8311116cf520398e816f928b06fdd90ec239d0488970101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60176101000a6101000a600055601760ff0a6101000a60015560176101010a6101000a60025560176101000a60ff0a600355601760ff0a60ff0a60045560176101010a60ff0a60055560176101000a6101010a600655601760ff0a6101010a60075560176101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_24.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_24.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_24": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_24Filler.json",
+            "sourceHash": "1b1fe064cbd99c44895bb1458e853c5564dfb749b8bfcf287f3df6bd89e8efa1"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60186101000a6101000a600055601860ff0a6101000a60015560186101010a6101000a60025560186101000a60ff0a600355601860ff0a60ff0a60045560186101010a60ff0a60055560186101000a6101010a600655601860ff0a6101010a60075560186101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d28c2",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60186101000a6101000a600055601860ff0a6101000a60015560186101010a6101000a60025560186101000a60ff0a600355601860ff0a60ff0a60045560186101010a60ff0a60055560186101000a6101010a600655601860ff0a6101010a60075560186101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x5c33085514ff7f00000000000000000000000000000000000000000000000001",
+                    "0x04": "0xd542e526003539ead104274aff2d78332366e29d328c2161f0c120731fe800ff",
+                    "0x05": "0xc706cb25e8384ce9bb5c9cb48415238ba03e16c448e292c0a101843b081800ff",
+                    "0x06": "0xb921f7aa6aff8100000000000000000000000000000000000000000000000001",
+                    "0x07": "0x4ca55f89202c524cb0f1cb3195d13c8d94a9f7a05c59e1d4031577c707e80101",
+                    "0x08": "0x8c4b0574e9156b80035f3ecdcf1fe79d273ed7559747a4322bcd338f20180101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60186101000a6101000a600055601860ff0a6101000a60015560186101010a6101000a60025560186101000a60ff0a600355601860ff0a60ff0a60045560186101010a60ff0a60055560186101000a6101010a600655601860ff0a6101010a60075560186101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_25.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_25.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_25": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_25Filler.json",
+            "sourceHash": "4ed286c5987852f3587a96e0a62db0c71f42819d4f41170980f68999a3fa39ef"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60196101000a6101000a600055601960ff0a6101000a60015560196101010a6101000a60025560196101000a60ff0a600355601960ff0a60ff0a60045560196101010a60ff0a60055560196101000a6101010a600655601960ff0a6101010a60075560196101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2868",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60196101000a6101000a600055601960ff0a6101000a60015560196101010a6101000a60025560196101000a60ff0a600355601960ff0a60ff0a60045560196101010a60ff0a60055560196101000a6101010a600655601960ff0a6101010a60075560196101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x33085514ff7f0000000000000000000000000000000000000000000000000001",
+                    "0x04": "0x7f510dd7198cac0a92ff7ea80451838c0dfa12114c41a0ef05907397f897feff",
+                    "0x05": "0x1275e752b6aee228ecba5e9b57ef1111deff3c651e2cfbf2cccd13151f9900ff",
+                    "0x06": "0x21f7aa6aff810000000000000000000000000000000000000000000000000001",
+                    "0x07": "0x6646340ad51a03bb710caf05756b685b33c7dad62ae68d369243700ead99ff01",
+                    "0x08": "0x29d80e8060ef2221929bb18215586c742686d6860e028ca0456b443238990101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60196101000a6101000a600055601960ff0a6101000a60015560196101010a6101000a60025560196101000a60ff0a600355601960ff0a60ff0a60045560196101010a60ff0a60055560196101000a6101010a600655601960ff0a6101010a60075560196101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_26.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_26.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_26": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_26Filler.json",
+            "sourceHash": "49a50ad563e91a351ed87dc845cf038941bb57aa95bce0a3a08019fd89526a6f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601a6101000a6101000a600055601a60ff0a6101000a600155601a6101010a6101000a600255601a6101000a60ff0a600355601a60ff0a60ff0a600455601a6101010a60ff0a600555601a6101000a6101010a600655601a60ff0a6101010a600755601a6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d280e",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601a6101000a6101000a600055601a60ff0a6101000a600155601a6101010a6101000a600255601a6101000a60ff0a600355601a60ff0a60ff0a600455601a6101010a60ff0a600555601a6101000a6101010a600655601a60ff0a6101010a600755601a6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x085514ff7f000000000000000000000000000000000000000000000000000001",
+                    "0x04": "0x1d164db738eb6893868b361ad2803f97be35764456e82a837667a693d1e600ff",
+                    "0x05": "0x8b92c24abebf376a5aab5ff4dfd3538a03d38a10bced2aae8e1a8a85b81a00ff",
+                    "0x06": "0xf7aa6aff81000000000000000000000000000000000000000000000000000001",
+                    "0x07": "0x6931bda98c70e860a1f6a5224940f1ec7e6734cd9456c95806384f7cb7e60101",
+                    "0x08": "0x3402a9db66492dfc2a220715e76243469462f24edc56903ba1d8e96ed21a0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601a6101000a6101000a600055601a60ff0a6101000a600155601a6101010a6101000a600255601a6101000a60ff0a600355601a60ff0a60ff0a600455601a6101010a60ff0a600555601a6101000a6101010a600655601a60ff0a6101010a600755601a6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_27.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_27.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_27": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_27Filler.json",
+            "sourceHash": "d18536cbfbe7764cf7b1db7e73548e6c789500233ac28437d68db8312c6270f8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601b6101000a6101000a600055601b60ff0a6101000a600155601b6101010a6101000a600255601b6101000a60ff0a600355601b60ff0a60ff0a600455601b6101010a60ff0a600555601b6101000a6101010a600655601b60ff0a6101010a600755601b6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d27b4",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601b6101000a6101000a600055601b60ff0a6101000a600155601b6101010a6101000a600255601b6101000a60ff0a600355601b60ff0a60ff0a600455601b6101010a60ff0a600555601b6101000a6101010a600655601b60ff0a6101010a600755601b6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x5514ff7f00000000000000000000000000000000000000000000000000000001",
+                    "0x04": "0x178918ffbcb401d4efd2f7dfb4d01a897172267f0f491121ac52dd614899feff",
+                    "0x05": "0x38ecff71480ca0b422f2ed6f780d5fead2ae234a49104b10a86f7f0dd19b00ff",
+                    "0x06": "0xaa6aff8100000000000000000000000000000000000000000000000000000001",
+                    "0x07": "0xd02811cb5dc1d80567e810532b235b7672f5c78cd6e89bb511d5e2d8f79bff01",
+                    "0x08": "0x1b4e6404f474c18055d30bb8987672f59e97980d6f9de1764c0fbec5ec9b0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601b6101000a6101000a600055601b60ff0a6101000a600155601b6101010a6101000a600255601b6101000a60ff0a600355601b60ff0a60ff0a600455601b6101010a60ff0a600555601b6101000a6101010a600655601b60ff0a6101010a600755601b6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_28.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_28.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_28": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_28Filler.json",
+            "sourceHash": "cb101db6bd5052385132e0babaacc212155afbfcb398b52b1b8baa08bd302052"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601c6101000a6101000a600055601c60ff0a6101000a600155601c6101010a6101000a600255601c6101000a60ff0a600355601c60ff0a60ff0a600455601c6101010a60ff0a600555601c6101000a6101010a600655601c60ff0a6101010a600755601c6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d275a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601c6101000a6101000a600055601c60ff0a6101000a600155601c6101010a6101000a600255601c6101000a60ff0a600355601c60ff0a60ff0a600455601c6101010a60ff0a600555601c6101000a6101010a600655601c60ff0a6101010a600755601c6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x14ff7f0000000000000000000000000000000000000000000000000000000001",
+                    "0x04": "0xffd368e44b3f85cb81ae394c9809ca9fa2db46a83d7880a912ab6d4a87e400ff",
+                    "0x05": "0x0981ad53c19b15a94bcf0bf20235dd0da9df25f46ae635029fe2062e6c1c00ff",
+                    "0x06": "0x6aff810000000000000000000000000000000000000000000000000000000001",
+                    "0x07": "0x19df06ffa28250867006726405fbc05d43dc2f9d2f025006db089bd46be40101",
+                    "0x08": "0x243fffe3a4f2982f45055c08f379648ab886da8027a7401117a8e0b8881c0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601c6101000a6101000a600055601c60ff0a6101000a600155601c6101010a6101000a600255601c6101000a60ff0a600355601c60ff0a60ff0a600455601c6101010a60ff0a600555601c6101000a6101010a600655601c60ff0a6101010a600755601c6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_29.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_29.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_29": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_29Filler.json",
+            "sourceHash": "f435d4f41de3ee732f642ff222f5a36be969401d4941fbe947aa17f23e5b1eda"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601d6101000a6101000a600055601d60ff0a6101000a600155601d6101010a6101000a600255601d6101000a60ff0a600355601d60ff0a60ff0a600455601d6101010a60ff0a600555601d6101000a6101010a600655601d60ff0a6101010a600755601d6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2700",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601d6101000a6101000a600055601d60ff0a6101000a600155601d6101010a6101000a600255601d6101000a60ff0a600355601d60ff0a60ff0a600455601d6101010a60ff0a600555601d6101000a6101010a600655601d60ff0a6101010a600755601d6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xff7f000000000000000000000000000000000000000000000000000000000001",
+                    "0x04": "0x41e065d46e0349cfe624c4e8a2034aea1f7edfff80e511cd8067d488949bfeff",
+                    "0x05": "0xa84162ca6675a22c4c79dfc4ea15f760db5a04dbf04246764199b668879d00ff",
+                    "0x06": "0xff81000000000000000000000000000000000000000000000000000000000001",
+                    "0x07": "0x1226984faa6b05ebdbd45d8477fa4fd5b55bfd5061de03c319282b153d9dff01",
+                    "0x08": "0x5cc9e6b0b749fd94541ad00364bdec2fca7816981ca3e38f485decc7a49d0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601d6101000a6101000a600055601d60ff0a6101000a600155601d6101010a6101000a600255601d6101000a60ff0a600355601d60ff0a60ff0a600455601d6101010a60ff0a600555601d6101000a6101010a600655601d60ff0a6101010a600755601d6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_3.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_3Filler.json",
+            "sourceHash": "0dce3aeccb3d6e15913863ede3bb4b2db122be2e79be3c1c9825cd7505152fb7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036101000a6101000a600055600360ff0a6101000a60015560036101010a6101000a60025560036101000a60ff0a600355600360ff0a60ff0a60045560036101010a60ff0a60055560036101000a6101010a600655600360ff0a6101010a60075560036101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d3024",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036101000a6101000a600055600360ff0a6101000a60015560036101010a6101000a60025560036101000a60ff0a600355600360ff0a60ff0a60045560036101010a60ff0a60055560036101000a6101010a600655600360ff0a6101010a60075560036101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x109a00e1370d2d2922bf892e85becb54297354b2e5c75388d514ff7f00000001",
+                    "0x04": "0x54a792f15e9aba7e4ad9e716bc169eea3a6e2e9c49bf9b335874613c8081feff",
+                    "0x05": "0x5d24a14d8e5e039372cd0f6a0f31e9ed6b75adba9f16b1c5b3edd5ba818300ff",
+                    "0x06": "0x298e2f316b4ccded5ebf515998d9ec20df69404b04a441782a6aff8100000001",
+                    "0x07": "0x4335694e98f372183c62a2339fa4ad161e9b4c42240bdc9452abffd07783ff01",
+                    "0x08": "0xf0f0820797315acd063056bba76f6a9c3e281cdb5197a233967ca94684830101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036101000a6101000a600055600360ff0a6101000a60015560036101010a6101000a60025560036101000a60ff0a600355600360ff0a60ff0a60045560036101010a60ff0a60055560036101000a6101010a600655600360ff0a6101010a60075560036101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_30.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_30.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_30": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_30Filler.json",
+            "sourceHash": "836e2f93a1ea7393c723482ec74da0f86ed2e0bad26a680e581b944ccbdf3e2f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601e6101000a6101000a600055601e60ff0a6101000a600155601e6101010a6101000a600255601e6101000a60ff0a600355601e60ff0a60ff0a600455601e6101010a60ff0a600555601e6101000a6101010a600655601e60ff0a6101010a600755601e6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d26a6",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601e6101000a6101000a600055601e60ff0a6101000a600155601e6101010a6101000a600255601e6101000a60ff0a600355601e60ff0a60ff0a600455601e6101010a60ff0a600555601e6101000a6101010a600655601e60ff0a6101010a600755601e6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x7f00000000000000000000000000000000000000000000000000000000000001",
+                    "0x04": "0xe9772778f50fa0a69cd10fa019ac56d72ac7a7d7af26c4ba28415c8f41e200ff",
+                    "0x05": "0x33f0385ef73feebdb952e5adb643dd0fa178fd9271578219ad50a73d241e00ff",
+                    "0x06": "0x8100000000000000000000000000000000000000000000000000000000000001",
+                    "0x07": "0xfd405cce8f73dffc04a6f0ff6ffc6bf7961876d09c5b4933a68f0cc623e20101",
+                    "0x08": "0xc5a8f4566fd2e96e4ce3a8b3ec0863e7b20bc3b2f3dc5261ba8a0174421e0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601e6101000a6101000a600055601e60ff0a6101000a600155601e6101010a6101000a600255601e6101000a60ff0a600355601e60ff0a60ff0a600455601e6101010a60ff0a600555601e6101000a6101010a600655601e60ff0a6101010a600755601e6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_31.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_31.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_31": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_31Filler.json",
+            "sourceHash": "c32144b90a00d75eea8d4681897298781d37480233d6e420d531fa569f5649c3"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601f6101000a6101000a600055601f60ff0a6101000a600155601f6101010a6101000a600255601f6101000a60ff0a600355601f60ff0a60ff0a600455601f6101010a60ff0a600555601f6101000a6101010a600655601f60ff0a6101010a600755601f6101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d264c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601f6101000a6101000a600055601f60ff0a6101000a600155601f6101010a6101000a600255601f6101000a60ff0a600355601f60ff0a60ff0a600455601f6101010a60ff0a600555601f6101000a6101010a600655601f60ff0a6101010a600755601f6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x01",
+                    "0x04": "0xf9cb87f5b1ab58602f52a1e9d392e5675b86a59a53943a8d4ec2a915dc9dfeff",
+                    "0x05": "0x893d729a64e318860ec5047e70e598da163eb41e71e74b04dfd4712d419f00ff",
+                    "0x06": "0x01",
+                    "0x07": "0xee5f2839c1b4f6ca05e6fdb04e2fb49c0f860b3765c27dc781a150cb7f9fff01",
+                    "0x08": "0xb4c358e3c6bcddfb509ea487d733df0e1854f29c3b6bfd4a8caabe3f609f0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601f6101000a6101000a600055601f60ff0a6101000a600155601f6101010a6101000a600255601f6101000a60ff0a600355601f60ff0a60ff0a600455601f6101010a60ff0a600555601f6101000a6101010a600655601f60ff0a6101010a600755601f6101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_32.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_32.json
@@ -1,0 +1,56 @@
+{
+    "expPowerOf256Of256_32": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_32Filler.json",
+            "sourceHash": "e1d465989d81ce4111dcea74490cb1361aa5f5635f0edfad8c0e7e6fad0a1f3a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60206101000a6101000a600055602060ff0a6101000a60015560206101010a6101000a60025560206101000a60ff0a600355602060ff0a60ff0a60045560206101010a60ff0a60055560206101000a6101010a600655602060ff0a6101010a60075560206101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0cef56",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60206101000a6101000a600055602060ff0a6101000a60015560206101010a6101000a60025560206101000a60ff0a600355602060ff0a60ff0a60045560206101010a60ff0a60055560206101000a6101010a600655602060ff0a6101010a60075560206101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01",
+                    "0x03": "0x01",
+                    "0x04": "0xb8247842bb5ce75c08d0c251669ed5870fa24a22952e5db3a7c66c59ffe000ff",
+                    "0x05": "0xee526e5a06f2a990b2bf6c951e5feabf0e07ee16877296e1be872db9e02000ff",
+                    "0x06": "0x01",
+                    "0x07": "0xeda7d024b6de40a9d3b966e71f10a4667edc5b71cab07aeabcac6249dfe00101",
+                    "0x08": "0x512ecfaeeb11205f0833e1054dcb1300488e0954be5af77a49e143aa00200101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60206101000a6101000a600055602060ff0a6101000a60015560206101010a6101000a60025560206101000a60ff0a600355602060ff0a60ff0a60045560206101010a60ff0a60055560206101000a6101010a600655602060ff0a6101010a60075560206101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_33.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_33.json
@@ -1,0 +1,56 @@
+{
+    "expPowerOf256Of256_33": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_33Filler.json",
+            "sourceHash": "c623b01168634203c89da2589bb7df04f1dfb9e7677d7d15aabc3e32bdcc4977"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60216101000a6101000a600055602160ff0a6101000a60015560216101010a6101000a60025560216101000a60ff0a600355602160ff0a60ff0a60045560216101010a60ff0a60055560216101000a6101010a600655602160ff0a6101010a60075560216101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0cef56",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60216101000a6101000a600055602160ff0a6101000a60015560216101010a6101000a60025560216101000a60ff0a600355602160ff0a60ff0a60045560216101010a60ff0a60055560216101000a6101010a600655602160ff0a6101010a60075560216101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01",
+                    "0x03": "0x01",
+                    "0x04": "0x8dcb65b5494eba78cd6756a6f9851f6e26d0f2bb9ecd7e9abd7e9b11209ffeff",
+                    "0x05": "0x6694bb31b20cd625f3756897dae6d738f2e64467b5b6f10fa3e07763ffa100ff",
+                    "0x06": "0x01",
+                    "0x07": "0xe678999aeffd1f1f45081f64de7f80ab083dd7df04721ed64ee04c03bda1ff01",
+                    "0x08": "0x39b68fb9898dd7568abd178397251ce8226a25c1d305a4e79573333520a10101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60216101000a6101000a600055602160ff0a6101000a60015560216101010a6101000a60025560216101000a60ff0a600355602160ff0a60ff0a60045560216101010a60ff0a60055560216101000a6101010a600655602160ff0a6101010a60075560216101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_4.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_4Filler.json",
+            "sourceHash": "dad1914780da70d243e1bfc111188d0b76f2babdc0b5707dfa31ace5b8b9a17a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60046101000a6101000a600055600460ff0a6101000a60015560046101010a6101000a60025560046101000a60ff0a600355600460ff0a60ff0a60045560046101010a60ff0a60055560046101000a6101010a600655600460ff0a6101010a60075560046101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2fca",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60046101000a6101000a600055600460ff0a6101000a60015560046101010a6101000a60025560046101000a60ff0a600355600460ff0a60ff0a60045560046101010a60ff0a60055560046101000a6101010a600655600460ff0a6101010a60075560046101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xe6540ce46eaf70da9d644015a661e0e245b13f307cb3885514ff7f0000000001",
+                    "0x04": "0x6526b38b05a6325b80e1c84ab41dc934fd70f33f1bd0eab3d1f61a4707fc00ff",
+                    "0x05": "0xe959516cd27e5d8fd487b72db2989b3ec2ba9fb7ead41554526fe5a3040400ff",
+                    "0x06": "0xe7498a48c6ce2530bbe814ee3440c8c44fffab7ad8a277aa6aff810000000001",
+                    "0x07": "0x2dffa3e901e5a392d15b79f4193d2168147d2aa7c55870b46c3a905d03fc0101",
+                    "0x08": "0xe16ea721c96539edb4f7fb82de0dad8cccb1e7a6966a6777635f6fb908040101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60046101000a6101000a600055600460ff0a6101000a60015560046101010a6101000a60025560046101000a60ff0a600355600460ff0a60ff0a60045560046101010a60ff0a60055560046101000a6101010a600655600460ff0a6101010a60075560046101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_5.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_5Filler.json",
+            "sourceHash": "d521557248ec7042f4ff4cb27e83dad00b7de39f67fd884872c5c70039295c51"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056101000a6101000a600055600560ff0a6101000a60015560056101010a6101000a60025560056101000a60ff0a600355600560ff0a60ff0a60045560056101010a60ff0a60055560056101000a6101010a600655600560ff0a6101010a60075560056101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2f70",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056101000a6101000a600055600560ff0a6101000a60015560056101010a6101000a60025560056101000a60ff0a600355600560ff0a60ff0a60045560056101010a60ff0a60055560056101000a6101010a600655600560ff0a6101010a60075560056101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0xb581ac185aad71db2d177c286929c4c22809e5dcb3085514ff7f000000000001",
+                    "0x04": "0x75789eb2a64bc971389fbd11a1e6d7abbf95ad25e23fb9aa25e73a0bfc83feff",
+                    "0x05": "0xfc403fa42ceb6a0d0d3321bd9b2d8af25b1b667f87a04f496c78168d078500ff",
+                    "0x06": "0xcec5ec213b9cb5811f6ae00428fd7b6ef5a1af39a1f7aa6aff81000000000001",
+                    "0x07": "0x70ab32233202b98d382d17713fa0be391eaf74f85ba1740c9c3238c4ed85ff01",
+                    "0x08": "0xb622672a213faa79b32185ff93a7b27a8499e48f7b032cdb4d1a70300c850101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056101000a6101000a600055600560ff0a6101000a60015560056101010a6101000a60025560056101000a60ff0a600355600560ff0a60ff0a60045560056101010a60ff0a60055560056101000a6101010a600655600560ff0a6101010a60075560056101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_6.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_6Filler.json",
+            "sourceHash": "6e2d9b87481f2253e37e45e55db466a7a49b761563d83b1fcde77c1c52a37d7a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60066101000a6101000a600055600660ff0a6101000a60015560066101010a6101000a60025560066101000a60ff0a600355600660ff0a60ff0a60045560066101010a60ff0a60055560066101000a6101010a600655600660ff0a6101010a60075560066101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2f16",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60066101000a6101000a600055600660ff0a6101000a60015560066101010a6101000a60025560066101000a60ff0a600355600660ff0a60ff0a60045560066101010a60ff0a60055560066101000a6101010a600655600660ff0a6101010a60075560066101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x1948059de1def03c4ec35fc22c2bb8f2bf45dc33085514ff7f00000000000001",
+                    "0x04": "0x41f818a8e24eb6d7bb7b193b4f2b5fdcf4bd0d453f2ac3499d8830d391fa00ff",
+                    "0x05": "0xede6fe4a943dfb5d967a2b85d6728759d40d2ef0ae4bc28bbb1867f98c0600ff",
+                    "0x06": "0x083c936cbaad5de592badc2e142fe4ebd6103921f7aa6aff8100000000000001",
+                    "0x07": "0x57385019fe4e0939ca3f35c37cadfaf52fba5b1cdfb02def3866e8068bfa0101",
+                    "0x08": "0x810ac878bd98428f6be8c6426ba9f9da09e3e33bf4fe10bfa3f8b12c92060101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60066101000a6101000a600055600660ff0a6101000a60015560066101010a6101000a60025560066101000a60ff0a600355600660ff0a60ff0a60045560066101010a60ff0a60055560066101000a6101010a600655600660ff0a6101010a60075560066101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_7.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_7Filler.json",
+            "sourceHash": "42d6264b6debf7b7f85dfae49d36a9dac79291e10d6ac36d03784a2bc32ad790"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60076101000a6101000a600055600760ff0a6101000a60015560076101010a6101000a60025560076101000a60ff0a600355600760ff0a60ff0a60045560076101010a60ff0a60055560076101000a6101010a600655600760ff0a6101010a60075560076101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2ebc",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076101000a6101000a600055600760ff0a6101000a60015560076101010a6101000a60025560076101000a60ff0a600355600760ff0a60ff0a60045560076101010a60ff0a60055560076101000a6101010a600655600760ff0a6101010a60075560076101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x8bb02654111ad8c60ad8af132283a81f455c33085514ff7f0000000000000001",
+                    "0x04": "0xa8f75c129dbb8466d6703a2a0b8212131b3248d70e2478862ac40fe17485feff",
+                    "0x05": "0x5fd4d2de580383ee59f5e800ddb3f1717ceae03aede19d3dec5e5a69918700ff",
+                    "0x06": "0xc8624230b524b85d6340da48a5db20370fb921f7aa6aff810000000000000001",
+                    "0x07": "0x287b58a5a13cd7f454468ca616c181712f5ed25433a7d5a894b6ced35f87ff01",
+                    "0x08": "0x09930d11ac2804fa977bf951593c8dff8498779cc0cdc5812a4fba2f98870101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076101000a6101000a600055600760ff0a6101000a60015560076101010a6101000a60025560076101000a60ff0a600355600760ff0a60ff0a60045560076101010a60ff0a60055560076101000a6101010a600655600760ff0a6101010a60075560076101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_8.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_8.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_8": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_8Filler.json",
+            "sourceHash": "75b38172e5269228b75fb6145d150700d6e124c1218f6099304bd1d17d0fad3b"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x05f5e100",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60086101000a6101000a600055600860ff0a6101000a60015560086101010a6101000a60025560086101000a60ff0a600355600860ff0a60ff0a60045560086101010a60ff0a60055560086101000a6101010a600655600860ff0a6101010a60075560086101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x989680",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9682a2",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60086101000a6101000a600055600860ff0a6101000a60015560086101010a6101000a60025560086101000a60ff0a600355600860ff0a60ff0a60045560086101010a60ff0a60055560086101000a6101010a600655600860ff0a6101010a60075560086101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x230041a0e7602d6e459609ed39081ec55c33085514ff7f000000000000000001",
+                    "0x04": "0xc407d8a413ef9079ead457ed686a05ac81039c0cae0a7f6afd01e8461ff800ff",
+                    "0x05": "0x67a397e0692385e4cd83853aabce220a94d449e885fa867e96d3ef5e180800ff",
+                    "0x06": "0x70add926e753655d6d0ebe9c0f81368fb921f7aa6aff81000000000000000001",
+                    "0x07": "0x0bdce80b8378e43f13d454b9d0a4c83cf311b8eaa45d5122cfd544a217f80101",
+                    "0x08": "0x629c25790e1488998877a9ecdf0fb69637e77d8a4bdc1b46270093ba20080101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60086101000a6101000a600055600860ff0a6101000a60015560086101010a6101000a60025560086101000a60ff0a600355600860ff0a60ff0a60045560086101010a60ff0a60055560086101000a6101010a600655600860ff0a6101010a60075560086101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_9.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256Of256_9.json
@@ -1,0 +1,55 @@
+{
+    "expPowerOf256Of256_9": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256Of256_9Filler.json",
+            "sourceHash": "e587592b571fbbe7615488d432734f5c34a9bfde62b7d57bdf7643b9b7c06cbe"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60096101000a6101000a600055600960ff0a6101000a60015560096101010a6101000a60025560096101000a60ff0a600355600960ff0a60ff0a60045560096101010a60ff0a60055560096101000a6101010a600655600960ff0a6101010a60075560096101010a6101010a600855",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0d2e08",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60096101000a6101000a600055600960ff0a6101000a60015560096101010a6101000a60025560096101000a60ff0a600355600960ff0a60ff0a60045560096101010a60ff0a60055560096101000a6101010a600655600960ff0a6101010a60075560096101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {
+                    "0x03": "0x53017d8eb210db2c8cd4a299079ec55c33085514ff7f00000000000000000001",
+                    "0x04": "0x48be09b6c6ae2aa660f1972125cecbb1038b5d236ecf766ba786e2c4e887feff",
+                    "0x05": "0x2e350d847ba73dc2099f83f532951c47269d9fd7e411b50bae00a9581f8900ff",
+                    "0x06": "0x013ab9e1f0df89a184b4d07080b68fb921f7aa6aff8100000000000000000001",
+                    "0x07": "0xf387ed41c1050f9da667f429a3e8fb30b61a55ede97d7b8acd797a03cd89ff01",
+                    "0x08": "0x525696c22bb3ce00fd2e3f6bbb9b4ea1046a5e31fcff2fedf8f8c74d28890101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60096101000a6101000a600055600960ff0a6101000a60015560096101010a6101000a60025560096101000a60ff0a600355600960ff0a60ff0a60045560096101010a60ff0a60055560096101000a6101010a600655600960ff0a6101010a60075560096101010a6101010a600855",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_1.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_1Filler.json",
+            "sourceHash": "16fbb934771f5b2053b1f20ae4912c1463295567cc2d56f98315a4847d507d8d"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016101000a600055600160ff0a60015560016101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101000a600055600160ff0a60015560016101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100",
+                    "0x01": "0xff",
+                    "0x02": "0x0101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016101000a600055600160ff0a60015560016101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_10.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_10.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_10": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_10Filler.json",
+            "sourceHash": "c63ab981f2085459076e378507c47ee6ae6605fe8d356e22e9f967c88f906729"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600a6101000a600055600a60ff0a600155600a6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600a6101000a600055600a60ff0a600155600a6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000",
+                    "0x01": "0xf62c88d104d1882cf601",
+                    "0x02": "0x010a2d78d2fcd2782d0a01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600a6101000a600055600a60ff0a600155600a6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_11.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_11.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_11": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_11Filler.json",
+            "sourceHash": "488cd4227d456590e5c90d6e733bd187917a08172f5f269601312376eb1da33f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600b6101000a600055600b60ff0a600155600b6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600b6101000a600055600b60ff0a600155600b6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000",
+                    "0x01": "0xf5365c4833ccb6a4c90aff",
+                    "0x02": "0x010b37a64bcfcf4aa5370b01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600b6101000a600055600b60ff0a600155600b6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_12.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_12.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_12": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_12Filler.json",
+            "sourceHash": "392226c24466abfe4500da731a41e3693e3155cea8837345bd658aa07d1b4bf0"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600c6101000a600055600c60ff0a600155600c6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600c6101000a600055600c60ff0a600155600c6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000",
+                    "0x01": "0xf44125ebeb98e9ee2441f401",
+                    "0x02": "0x010c42ddf21b9f19efdc420c01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600c6101000a600055600c60ff0a600155600c6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_13.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_13.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_13": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_13Filler.json",
+            "sourceHash": "beec37a23ab8455cf107f21d8e32c666cdf69008d21693dadc1aa180a13a8122"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600d6101000a600055600d60ff0a600155600d6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d6101000a600055600d60ff0a600155600d6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000",
+                    "0x01": "0xf34ce4c5ffad5104361db20cff",
+                    "0x02": "0x010d4f20d00dbab909cc1e4e0d01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d6101000a600055600d60ff0a600155600d6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_14.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_14.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_14": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_14Filler.json",
+            "sourceHash": "186d50e93b2675aede0d915df14710897296065bc2548b6995173836782699c3"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600e6101000a600055600e60ff0a600155600e6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600e6101000a600055600e60ff0a600155600e6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000",
+                    "0x01": "0xf25997e139ada3b331e7945af201",
+                    "0x02": "0x010e5c6ff0ddc873c2d5ea6c5b0e01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600e6101000a600055600e60ff0a600155600e6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_15.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_15.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_15": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_15Filler.json",
+            "sourceHash": "7f5b408ef1627c7a1a13a6a16e1d1e2d3f28c25eb0f7bd36612b3658e97d3b66"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600f6101000a600055600f60ff0a600155600f6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600f6101000a600055600f60ff0a600155600f6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000",
+                    "0x01": "0xf1673e495873f60f7eb5acc6970eff",
+                    "0x02": "0x010f6acc60cea63c3698c056c7690f01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600f6101000a600055600f60ff0a600155600f6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_16.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_16.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_16": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_16Filler.json",
+            "sourceHash": "13123c5b15072c7b2d4258e85ffe16cad4967c2b795995fb82caf0c55bea5777"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60106101000a600055601060ff0a60015560106101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60106101000a600055601060ff0a60015560106101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000",
+                    "0x01": "0xf075d70b0f1b82196f36f719d077f001",
+                    "0x02": "0x01107a372d2f74e272cf59171e30781001"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60106101000a600055601060ff0a60015560106101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_17.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_17.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_17": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_17Filler.json",
+            "sourceHash": "e45eb8d13c33e2f326c300991ee94c7fc355f6d4b403b9997eae4af384f9c718"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60116101000a600055601160ff0a60015560116101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60116101000a600055601160ff0a60015560116101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000000000",
+                    "0x01": "0xef856134040c669755c7c022b6a77810ff",
+                    "0x02": "0x01118ab1645ca45755422870354ea8881101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60116101000a600055601160ff0a60015560116101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_18.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_18.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_18": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_18Filler.json",
+            "sourceHash": "d6cb5476907369ace6f89dedb6cfa48e6206d06323014b63e3d3412a88b7f1ae"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60126101000a600055601260ff0a60015560126101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60126101000a600055601260ff0a60015560126101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000000000",
+                    "0x01": "0xee95dbd2d0085a30be71f86293f0d098ee01",
+                    "0x02": "0x01129c3c15c100fbac976a98a583f730991201"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60126101000a600055601260ff0a60015560126101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_19.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_19.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_19": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_19Filler.json",
+            "sourceHash": "e4aa661fa827549475ed5e8301714d2e0b43e9291b216b4bf746c344d585e773"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60136101000a600055601360ff0a60015560136101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60136101000a600055601360ff0a60015560136101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000000000",
+                    "0x01": "0xeda745f6fd3851d68db3866a315cdfc85512ff",
+                    "0x02": "0x0113aed851d6c1fca84402033e297b27c9ab1301"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60136101000a600055601360ff0a60015560136101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_2.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_2Filler.json",
+            "sourceHash": "07bcef4266f5ee70819d4ea7a9ea2d20b13548c86dfca80360c7aea1797f3f95"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026101000a600055600260ff0a60015560026101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026101000a600055600260ff0a60015560026101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000",
+                    "0x01": "0xfe01",
+                    "0x02": "0x010201"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026101000a600055600260ff0a60015560026101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_20.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_20.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_20": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_20Filler.json",
+            "sourceHash": "ef33504fb8f230ffc923208053a633ed892145c0593ef054be30e0f4977a9ec5"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60146101000a600055601460ff0a60015560146101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60146101000a600055601460ff0a60015560146101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000000000000000",
+                    "0x01": "0xecb99eb1063b1984b725d2e3c72b82e88cbdec01",
+                    "0x02": "0x0114c2872a2898bea4ec46054167a4a2f174be1401"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60146101000a600055601460ff0a60015560146101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_21.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_21.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_21": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_21Filler.json",
+            "sourceHash": "77271e189f1f301640781da5858de66b9d98f84f479b123be34f26caa64adb67"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60156101000a600055601560ff0a60015560156101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60156101000a600055601560ff0a60015560156101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000000000000000",
+                    "0x01": "0xebcce5125534de6b326ead10e3645765a4312e14ff",
+                    "0x02": "0x0115d749b152c1576391324b46a90c47946632d21501"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60156101000a600055601560ff0a60015560156101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_22.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_22.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_22": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_22Filler.json",
+            "sourceHash": "d056976d2b6ecf266c5288e4b5fd652f4cb3171eae3ea68a22acf7bdf6bdaf84"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60166101000a600055601660ff0a60015560166101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60166101000a600055601660ff0a60015560166101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000000000000000",
+                    "0x01": "0xeae1182d42dfa98cc73c3e63d280f30e3e8cfce6ea01",
+                    "0x02": "0x0116ed20fb041418baf4c37d91efb553dbfa9904e71601"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60166101000a600055601660ff0a60015560166101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_23.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_23.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_23": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_23Filler.json",
+            "sourceHash": "542a9061397115d3c2937ee3dc44d6b196395066f3f8c6518f5bd18bef810169"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60176101000a600055601760ff0a60015560176101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60176101000a600055601760ff0a60015560176101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000000000000000000000",
+                    "0x01": "0xe9f63715159cc9e33a7502256eae721b304e6fea0316ff",
+                    "0x02": "0x0118040e1bff182cd3afb8410f81a5092fd6939debfd1701"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60176101000a600055601760ff0a60015560176101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_24.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_24.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_24": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_24Filler.json",
+            "sourceHash": "8e029ce9c0f33ceaf1e0c2986f76854604f5bd12018671227a705ae57bdb57d8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60186101000a600055601860ff0a60015560186101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60186101000a600055601860ff0a60015560186101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe90c40de00872d19573a8d23493fc3a9151e217a1913e801",
+                    "0x02": "0x01191c122a1b1745008367f9509126ae39066a3189e9141801"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60186101000a600055601860ff0a60015560186101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_25.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_25.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_25": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_25Filler.json",
+            "sourceHash": "b3b3a03b8a78799b64a89907a0b351f914efa445edc2e0f025e4dc509b9941e7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60196101000a600055601960ff0a60015560196101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60196101000a600055601960ff0a60015560196101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe823349d2286a5ec3de3529625f683e56c0903589efad418ff",
+                    "0x02": "0x011a352e3c45325c4583eb6149e1b7d4e73f709bbb72fd2c1901"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60196101000a600055601960ff0a60015560196101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_26.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_26.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_26": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_26Filler.json",
+            "sourceHash": "3d1bb918bab2151b24714c254572c07f762c398ae4cf21890c16c89037ce8597"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601a6101000a600055601a60ff0a600155601a6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601a6101000a600055601a60ff0a600155601a6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe73b116885641f4651a56f438fd08d61869cfa55465bd944e601",
+                    "0x02": "0x011b4f636a81778ea1c96f4cab2b998cbc26b00c572e7029451a01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601a6101000a600055601a60ff0a600155601a6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_27.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_27.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_27": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_27Filler.json",
+            "sourceHash": "15f8c1655a2cf4350b9701ab6324da8472b3b0faf350cd832b89e3a46b544141"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601b6101000a600055601b60ff0a600155601b6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601b6101000a600055601b60ff0a600155601b6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe653d6571cdebb270b53c9d44c40bcd425165d5af1157d6ba11aff",
+                    "0x02": "0x011c6ab2cdebf906306b38bbf7d6c52648e2d6bc63859e996e5f1b01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601b6101000a600055601b60ff0a600155601b6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_28.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_28.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_28": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_28Filler.json",
+            "sourceHash": "638ec46c0d46a31e2e58efb22cc0b7c473f7c11c9b0092e63f506daeb42f117b"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601c6101000a600055601c60ff0a600155601c6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601c6101000a600055601c60ff0a600155601c6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe56d8280c5c1dc6be448760a77f47c1750f146fd962467ee3579e401",
+                    "0x02": "0x011d871d80b9e4ff369ba3f4b3ce9beb6f2bb9931fe9243807cd7a1c01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601c6101000a600055601c60ff0a600155601c6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_29.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_29.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_29": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_29Filler.json",
+            "sourceHash": "e4d60adbb00c35e28179c0b6793a53dd44ebb6634391262a91db041e74b87f5c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601d6101000a600055601d60ff0a600155601d6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601d6101000a600055601d60ff0a600155601d6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe48814fe44fc1a8f78642d946d7c879b39a055b6988e438647446a1cff",
+                    "0x02": "0x011ea4a49e3a9ee435d23f98a8826a875a9ae54cb3090d5c3fd547961d01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601d6101000a600055601d60ff0a600155601d6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_3.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_3Filler.json",
+            "sourceHash": "d2e71f04de753763b76ffe0a540fd9adaa461138b28e6aa42515c18f48b95f92"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036101000a600055600360ff0a60015560036101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036101000a600055600360ff0a60015560036101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000",
+                    "0x01": "0xfd02ff",
+                    "0x02": "0x01030301"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036101000a600055600360ff0a60015560036101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_30.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_30.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_30": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_30Filler.json",
+            "sourceHash": "ce02670f9d0a42f0ac3c6975d19e3e2dfc15668e388b6f7e45c3d9bc80b51764"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601e6101000a600055601e60ff0a600155601e6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601e6101000a600055601e60ff0a600155601e6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe3a38ce946b71e74e8ebc966d90f0b139e66b560e1f5b542c0fd25b2e201",
+                    "0x02": "0x011fc34942d8d9831a0811d8412aecf1e1f58031ffbc16699c151cddb31e01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601e6101000a600055601e60ff0a600155601e6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_31.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_31.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_31": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_31Filler.json",
+            "sourceHash": "c685cc3472bda9ae8656c5473614b288c46282486b62064446996feac51be396"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601f6101000a600055601f60ff0a600155601f6101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601f6101000a600055601f60ff0a600155601f6101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000000000000000000000000000000000",
+                    "0x01": "0xe2bfe95c5d7067567402dd9d7235fc088ac84eab8113bf8d7e3c288d2f1eff",
+                    "0x02": "0x0120e30c8c1bb25c9d2219ea196c17ded3d775b231bbd28005b131fa90d11f01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601f6101000a600055601f60ff0a600155601f6101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_32.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_32.json
@@ -1,0 +1,51 @@
+{
+    "expPowerOf256_32": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_32Filler.json",
+            "sourceHash": "ed1e00709ee87288d5782c4551742366f9e0a4604bf0e2ff5990c56e70dcbc74"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60206101000a600055602060ff0a60015560206101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0xd681",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60206101000a600055602060ff0a60015560206101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x01": "0xe1dd29730112f6ef1d8edabfd4c3c60c823d865cd592abcdf0bdec64a1efe001",
+                    "0x02": "0x2203ef98a7ce0ef9bf3c04038583f6b2ab4d27e3ed8e5285b6e32c8b61f02001"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60206101000a600055602060ff0a60015560206101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_33.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_33.json
@@ -1,0 +1,51 @@
+{
+    "expPowerOf256_33": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_33Filler.json",
+            "sourceHash": "0c39167ce593ed18cf8bcd9bcc8c9db07079b9c77f3b326386f09d8745564767"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60216101000a600055602160ff0a60015560216101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0xd681",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60216101000a600055602160ff0a60015560216101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x01": "0xfb4c498e11e3f82e714be514ef024675bb48d678bd192222cd2e783d4df020ff",
+                    "0x02": "0x25f3884075dd08b8fb400789097aa95df8750bd17be0d83c9a0fb7ed52102101"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60216101000a600055602160ff0a60015560216101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_4.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_4Filler.json",
+            "sourceHash": "44609edd4d65ccd35dec7c2b4996adc009e3d890dcce6e8447cb8545fdd915ab"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60046101000a600055600460ff0a60015560046101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60046101000a600055600460ff0a60015560046101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000",
+                    "0x01": "0xfc05fc01",
+                    "0x02": "0x0104060401"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60046101000a600055600460ff0a60015560046101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_5.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_5Filler.json",
+            "sourceHash": "c4e1fe9047ec92e28a022218cce8f6bf476463abccc5c38c8820adc0eecee7a8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056101000a600055600560ff0a60015560056101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056101000a600055600560ff0a60015560056101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000",
+                    "0x01": "0xfb09f604ff",
+                    "0x02": "0x01050a0a0501"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056101000a600055600560ff0a60015560056101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_6.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_6Filler.json",
+            "sourceHash": "7a1e9d28321fad6512955ef132b0ad2e97ae3f9a0888815f1fa3ff9ae8f8c617"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60066101000a600055600660ff0a60015560066101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60066101000a600055600660ff0a60015560066101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000",
+                    "0x01": "0xfa0eec0efa01",
+                    "0x02": "0x01060f140f0601"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60066101000a600055600660ff0a60015560066101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_7.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_7Filler.json",
+            "sourceHash": "aab76c2cdd95f40bd93b061e7a091919a5698cd8c91d573bea426f1300dc3d35"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60076101000a600055600760ff0a60015560076101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076101000a600055600760ff0a60015560076101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000",
+                    "0x01": "0xf914dd22eb06ff",
+                    "0x02": "0x0107152323150701"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60076101000a600055600760ff0a60015560076101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_8.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_8.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_8": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_8Filler.json",
+            "sourceHash": "a318d780fe83ecdba8804c0638ea6bf83757fb82bd136a0a6b3f2fb8d7326ea6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60086101000a600055600860ff0a60015560086101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60086101000a600055600860ff0a60015560086101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000",
+                    "0x01": "0xf81bc845c81bf801",
+                    "0x02": "0x01081c3846381c0801"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60086101000a600055600860ff0a60015560086101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_9.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf256_9.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf256_9": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf256_9Filler.json",
+            "sourceHash": "1ad447853761cecd48d31238ba56b2455cdb67c77deff367b8674250f8ef379b"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60096101000a600055600960ff0a60015560096101010a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60096101000a600055600960ff0a60015560096101010a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01000000000000000000",
+                    "0x01": "0xf723ac7d8253dc08ff",
+                    "0x02": "0x010924547e7e54240901"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60096101000a600055600960ff0a60015560096101010a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_128.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_128.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_128": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_128Filler.json",
+            "sourceHash": "3ba0fa1e755f39f2f3c0a33d9d70d454071b9ae199c0be6a86819825a1957c9f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x608060020a600055607f60020a600155608160020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x608060020a600055607f60020a600155608160020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000000000000000000000000000",
+                    "0x01": "0x80000000000000000000000000000000",
+                    "0x02": "0x0200000000000000000000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x608060020a600055607f60020a600155608160020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_16.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_16.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_16": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_16Filler.json",
+            "sourceHash": "fdfb5f99a61b0b4a955190a7134fc443ea97b835570ea6f295d6f059b710b00d"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x601060020a600055600f60020a600155601160020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601060020a600055600f60020a600155601160020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000",
+                    "0x01": "0x8000",
+                    "0x02": "0x020000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x601060020a600055600f60020a600155601160020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_2.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_2Filler.json",
+            "sourceHash": "06c5b279048c557ce587da83ebe49154e4a9807add4c95f204be3eb8f736c437"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600260020a600055600160020a600155600360020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600260020a600055600160020a600155600360020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x04",
+                    "0x01": "0x02",
+                    "0x02": "0x08"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600260020a600055600160020a600155600360020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_256.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_256.json
@@ -1,0 +1,50 @@
+{
+    "expPowerOf2_256": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_256Filler.json",
+            "sourceHash": "c83759ae4217b107fe9faa4149b0d22de89653b76fbeb55eb53951caca817fef"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x61010060020a60005560ff60020a60015561010160020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x011105",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010060020a60005560ff60020a60015561010160020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x01": "0x8000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x61010060020a60005560ff60020a60015561010160020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_32.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_32.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_32": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_32Filler.json",
+            "sourceHash": "eb328b22481e99d35dc854a7ee9b903627ea9acbdc844233ecdea53b6f02174a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x602060020a600055601f60020a600155602160020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x602060020a600055601f60020a600155602160020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100000000",
+                    "0x01": "0x80000000",
+                    "0x02": "0x0200000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x602060020a600055601f60020a600155602160020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_4.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_4Filler.json",
+            "sourceHash": "91dfec0880b67536467cc81c7a4f2a55a5ff53b2a2941a672ecb9ed42bc04561"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600460020a600055600360020a600155600560020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600460020a600055600360020a600155600560020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x10",
+                    "0x01": "0x08",
+                    "0x02": "0x20"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600460020a600055600360020a600155600560020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_64.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_64.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_64": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_64Filler.json",
+            "sourceHash": "70d2fcbc9e3456de712e542f42cde87b9758362ef951449a5f7d41f007b29708"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x604060020a600055603f60020a600155604160020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x604060020a600055603f60020a600155604160020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x010000000000000000",
+                    "0x01": "0x8000000000000000",
+                    "0x02": "0x020000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x604060020a600055603f60020a600155604160020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_8.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expPowerOf2_8.json
@@ -1,0 +1,52 @@
+{
+    "expPowerOf2_8": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expPowerOf2_8Filler.json",
+            "sourceHash": "db4de73e43dc419435540b961648502905afd5dfc55e7f99610e3fd8979183c4"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600860020a600055600760020a600155600960020a600255",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9be9",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600860020a600055600760020a600155600960020a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x0100",
+                    "0x01": "0x80",
+                    "0x02": "0x0200"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600860020a600055600760020a600155600960020a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expXY.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expXY.json
@@ -1,0 +1,51 @@
+{
+    "expXY": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expXYFiller.json",
+            "sourceHash": "f7f1a3990ae066728de05044ac8f19daf7424ccb5e2f8ec6fa6face0255c12f9"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000356000556020356001556001546000540a600255",
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000100000000000f",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0xd609",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000356000556020356001556001546000540a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02",
+                    "0x01": "0x0100000000000f"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000356000556020356001556001546000540a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/expXY_success.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/expXY_success.json
@@ -1,0 +1,52 @@
+{
+    "expXY_success": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/expXY_successFiller.json",
+            "sourceHash": "bc5f7a7dca50ae0a0dd7bb43a0e68a9c679fcde4627892a49fbdc23b0a86b36a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000356000556020356001556001546000540a600255",
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000f",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x9bad",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000356000556020356001556001546000540a600255",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02",
+                    "0x01": "0x0f",
+                    "0x02": "0x8000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000356000556020356001556001546000540a600255",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/fibbonacci_unrolled.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/fibbonacci_unrolled.json
@@ -1,0 +1,48 @@
+{
+    "fibbonacci_unrolled": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/fibbonacci_unrolledFiller.json",
+            "sourceHash": "cbc88733153817d7697a91c79578e3939706a9c1a8ac266ec9fa6ba8b59f98ef"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810160005260206000f3",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f4192",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x0000000000000000000000000000000000000000000000000000000000001055",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810160005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810181810160005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mod0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mod0.json
@@ -1,0 +1,50 @@
+{
+    "mod0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mod0Filler.json",
+            "sourceHash": "2ee0b9c5d36fbae6850da8779fa82661baf68b125e45a87aa4eacdc638a973c1"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600206600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600206600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600206600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mod1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mod1.json
@@ -1,0 +1,50 @@
+{
+    "mod1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mod1Filler.json",
+            "sourceHash": "3138621aabbedf44390f461a78f53dfa3ab9e6fcd0e04c6a0b31eb75b8261364"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff06600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff06600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60027fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff06600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mod2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mod2.json
@@ -1,0 +1,48 @@
+{
+    "mod2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mod2Filler.json",
+            "sourceHash": "17781cb1fcbf60a7680ad7ce993f3d531bcf81a0ef845baf9983d317119739b7"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600006600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600006600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600006600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mod3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mod3.json
@@ -1,0 +1,48 @@
+{
+    "mod3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mod3Filler.json",
+            "sourceHash": "252164a18d03038559d91387308a8e52b869c02b0a715ba7bd6d4bd816b60eca"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000600306600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600306600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600306600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mod4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mod4.json
@@ -1,0 +1,50 @@
+{
+    "mod4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mod4Filler.json",
+            "sourceHash": "e2c9a9e2ac84e9998d6ab4d4cd3283fa6df50c698d8d379ad3949aaf5ba979e5"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600260000306600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600260000306600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600260000306600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/modByZero.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/modByZero.json
@@ -1,0 +1,50 @@
+{
+    "modByZero": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/modByZeroFiller.json",
+            "sourceHash": "4b5746b40add45b15482297434254e8f3a3e6a2177c2707d6cc362e234de5be0"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600060030603600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600060030603600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600060030603600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul0.json
@@ -1,0 +1,50 @@
+{
+    "mul0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul0Filler.json",
+            "sourceHash": "58a9a1865a396b48964d80bbb835a11fdf04b8670f874822871ad3f47ae00e46"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600202600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600202600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x06"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600202600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul1.json
@@ -1,0 +1,50 @@
+{
+    "mul1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul1Filler.json",
+            "sourceHash": "875d4975af8db905121dd74af67a360fdb7575e4bd1a7395f7dc4b47c543a988"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul2.json
@@ -1,0 +1,48 @@
+{
+    "mul2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul2Filler.json",
+            "sourceHash": "1bc06846ec1e58b28be79a89ba57b6e5ede91b194cd92e83c00f8aea24b850fa"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6017600002600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6017600002600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6017600002600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul3.json
@@ -1,0 +1,50 @@
+{
+    "mul3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul3Filler.json",
+            "sourceHash": "784a4bac2f908a96f896815e46ce348906b2e013ac96a37f2aaff419574b62c2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001601702600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001601702600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x17"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001601702600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul4.json
@@ -1,0 +1,50 @@
+{
+    "mul4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul4Filler.json",
+            "sourceHash": "45dd057a18eccb8d25d9d9b21108e8417cc0761f7441acdb70e950ea30d571c3"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f800000000000000000000000000000000000000000000000000000000000000002600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f800000000000000000000000000000000000000000000000000000000000000002600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x8000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f800000000000000000000000000000000000000000000000000000000000000002600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul5.json
@@ -1,0 +1,48 @@
+{
+    "mul5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul5Filler.json",
+            "sourceHash": "89549d49e7483833a4e34bab92c0c0420616e9ec8142ff4b2e27f53073856c71"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f80000000000000000000000000000000000000000000000000000000000000007f800000000000000000000000000000000000000000000000000000000000000002600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01730a",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f80000000000000000000000000000000000000000000000000000000000000007f800000000000000000000000000000000000000000000000000000000000000002600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f80000000000000000000000000000000000000000000000000000000000000007f800000000000000000000000000000000000000000000000000000000000000002600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul6.json
@@ -1,0 +1,50 @@
+{
+    "mul6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul6Filler.json",
+            "sourceHash": "bca12e44c9757affee296b2c9b32f146aeba5a8c4f15c889529fb7ee8058d1f0"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013872",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mul7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mul7.json
@@ -1,0 +1,48 @@
+{
+    "mul7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mul7Filler.json",
+            "sourceHash": "95a46849ec2ea26374c55eca1469a84aba7113c5d1c3f2b114a21e8afef66a09"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba0987654321020260005260206000f3",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01867e",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x47d0817e4167b1eb4f9fc722b133ef9d7d9a6fb4c2c1c442d000107a5e419561",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba0987654321020260005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba09876543217001234567890abcdef0fedcba0987654321020260005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulUnderFlow.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulUnderFlow.json
@@ -1,0 +1,36 @@
+{
+    "mulUnderFlow": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulUnderFlowFiller.json",
+            "sourceHash": "c4dc43a2d2480a375b5f4cde0ff0b1059f36577d7c555b2ee92db62aad36aea2"
+        },
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600102600155",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600102600155",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod0.json
@@ -1,0 +1,48 @@
+{
+    "mulmod0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod0Filler.json",
+            "sourceHash": "767b5508cdc961f3ca017e91c51e48ad932aa626883b9e6cb0a7f5d9caa62618"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026002600109600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600109600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026002600109600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod1.json
@@ -1,0 +1,48 @@
+{
+    "mulmod1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod1Filler.json",
+            "sourceHash": "6b32e8069707bd5ee71ec2c2c303483bf358379065099649dc1766ec9a8442cd"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036002600003600160000309600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172f8",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036002600003600160000309600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036002600003600160000309600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow.json
@@ -1,0 +1,48 @@
+{
+    "mulmod1_overflow": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod1_overflowFiller.json",
+            "sourceHash": "bc67e288ab51605bc21b8bca2e08639cad3d4739d76643023a626c107779426d"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60056002600160000309600055",
+            "data": "0x",
+            "gas": "0x2710",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x136e",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600160000309600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60056002600160000309600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow2.json
@@ -1,0 +1,50 @@
+{
+    "mulmod1_overflow2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod1_overflow2Filler.json",
+            "sourceHash": "f763267bd021dd60da1d92fa3beabb939ef2d0d09a4e29ab0e32e8c3bd7b0dc9"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000009600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef40c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000009600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000009600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow3.json
@@ -1,0 +1,50 @@
+{
+    "mulmod1_overflow3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod1_overflow3Filler.json",
+            "sourceHash": "a7b60d2491579fdcaf5e94d93fe908f8b16b823d494ae3d9478c43f2ea7bd834"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600560027f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff09600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef40c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff09600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x04"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff09600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod1_overflow4.json
@@ -1,0 +1,50 @@
+{
+    "mulmod1_overflow4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod1_overflow4Filler.json",
+            "sourceHash": "922a50e498af6f9130867a28130ad6ef98f9a3c19165e317f3f9062011a14026"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000109600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef40c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000109600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x03"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560027f800000000000000000000000000000000000000000000000000000000000000109600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod2.json
@@ -1,0 +1,50 @@
+{
+    "mulmod2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod2Filler.json",
+            "sourceHash": "721a303cc662f31affb219ba697d1c1e171d1780e3c5b23f413ae6a3f94f81f4"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600560000309600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod2_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod2_0.json
@@ -1,0 +1,48 @@
+{
+    "mulmod2_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod2_0Filler.json",
+            "sourceHash": "57716635892e086cdf101b64850f412daa5737569899026b3b4eeff6639b0987"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600560000309600360056000030714600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172ea",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600360056000030714600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600360056000030714600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod2_1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod2_1.json
@@ -1,0 +1,50 @@
+{
+    "mulmod2_1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod2_1Filler.json",
+            "sourceHash": "c44cc47d3c21c1aa51395946e6023e82d076e5c128d370a346b0b1724843affa"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036001600560000309600360056000030614600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013852",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600360056000030614600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036001600560000309600360056000030614600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod3.json
@@ -1,0 +1,50 @@
+{
+    "mulmod3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod3Filler.json",
+            "sourceHash": "de5ef219cbf674cfaef91ab0dc8c1c7a3da96ca19789d82de96cdc831dd8e73b"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60036000036001600509600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036000036001600509600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x05"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60036000036001600509600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod3_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod3_0.json
@@ -1,0 +1,48 @@
+{
+    "mulmod3_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod3_0Filler.json",
+            "sourceHash": "9f7b685641648b59465a41a4a45e02ddefa2779c981ff4e24fbde810d4bdef39"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60026003600003600160050914600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172f8",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026003600003600160050914600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60026003600003600160050914600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmod4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmod4.json
@@ -1,0 +1,48 @@
+{
+    "mulmod4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmod4Filler.json",
+            "sourceHash": "32961c8198308c3d51e61132c8354292803bbd7b4ebb709745836535444d2071"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6064601b60250960005360006001f3",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x018680",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6064601b60250960005360006001f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6064601b60250960005360006001f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero.json
@@ -1,0 +1,48 @@
+{
+    "mulmoddivByZero": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmoddivByZeroFiller.json",
+            "sourceHash": "ec1ad3cf4c568d4d10c865a1c143e20e0bf35c8ab8eb8525c41820d95a88f897"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006001600509600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600509600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600509600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero1.json
@@ -1,0 +1,48 @@
+{
+    "mulmoddivByZero1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmoddivByZero1Filler.json",
+            "sourceHash": "b2a3da11358e5cb15711b465a7aa9bfea20c06ac8b0f0bdde036b3eefa6da57f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006001600009600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600009600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006001600009600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero2.json
@@ -1,0 +1,48 @@
+{
+    "mulmoddivByZero2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmoddivByZero2Filler.json",
+            "sourceHash": "a1ae353f9c34e7b84c7df86663186e618b091f99e14f66fa456dd8c26da748c8"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006000600109600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600109600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600109600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/mulmoddivByZero3.json
@@ -1,0 +1,50 @@
+{
+    "mulmoddivByZero3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/mulmoddivByZero3Filler.json",
+            "sourceHash": "207ae005ea9edb1b9286ace7da9e01e18edd1eb1c3b54a3ab75ed40e972d61be"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60006000600009600103600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600009600103600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60006000600009600103600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/not1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/not1.json
@@ -1,0 +1,48 @@
+{
+    "not1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/not1Filler.json",
+            "sourceHash": "759b4c3c3cce13205ae8c709fa287e6b0a0200ba5bceac5a7e380238aa5d0839"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6201e2406000526000511960005260206000f3",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f421f",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe1dbf",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6201e2406000526000511960005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6201e2406000526000511960005260206000f3",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv0.json
@@ -1,0 +1,50 @@
+{
+    "sdiv0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv0Filler.json",
+            "sourceHash": "e4fed1dd5885f1f6088f4679cd777c957b2c4923e262e50eceddebb987a61a6e"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv1.json
@@ -1,0 +1,50 @@
+{
+    "sdiv1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv1Filler.json",
+            "sourceHash": "abca0305e362717e8a2b262b8c38c47a57150b4e394438f836822d4ae48b0342"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv2.json
@@ -1,0 +1,48 @@
+{
+    "sdiv2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv2Filler.json",
+            "sourceHash": "ae9eb1a676c36b5f43d26e77be0c090c049b0abf00cfadb9847276e30ec90b91"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6004600003600260000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172fe",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6004600003600260000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6004600003600260000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv3.json
@@ -1,0 +1,50 @@
+{
+    "sdiv3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv3Filler.json",
+            "sourceHash": "cdd045efd78c8fc52fe371516bb320b083c270e2e3888389bafabc0072a33c0c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6002600003600405600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6002600003600405600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6002600003600405600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv4.json
@@ -1,0 +1,50 @@
+{
+    "sdiv4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv4Filler.json",
+            "sourceHash": "5f3b61a3213e0be0199b3452f82e31f042f601e96b8e2240ef4b18a219f55adf"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6004600003600505600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6004600003600505600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6004600003600505600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv5.json
@@ -1,0 +1,50 @@
+{
+    "sdiv5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv5Filler.json",
+            "sourceHash": "68a55929a068949809b9fd06e0650f45d44d5eaa6b5374174340c247ffce0f73"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x8000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv6.json
@@ -1,0 +1,48 @@
+{
+    "sdiv6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv6Filler.json",
+            "sourceHash": "f86bb63df09d84d1101adaca3ced246f40d1d5208fae50651ed2db3f3aedf066"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60007f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv7.json
@@ -1,0 +1,48 @@
+{
+    "sdiv7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv7Filler.json",
+            "sourceHash": "64f233a88f621945fa94a7002544d422f21b923d38b755d975edd9b753ae6fca"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6019600160000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6019600160000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6019600160000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv8.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv8.json
@@ -1,0 +1,50 @@
+{
+    "sdiv8": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv8Filler.json",
+            "sourceHash": "e7cb1b031ab156524184d4e69a5f0cb5aa42838e7365698c169be854f98a2dae"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600003600160000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600003600160000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600003600160000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv9.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv9.json
@@ -1,0 +1,50 @@
+{
+    "sdiv9": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv9Filler.json",
+            "sourceHash": "1488f69cbe8c316493e178df4f6b3c451f1bf3bd6985521dd1d0b95e388a5851"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001600160000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600160000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001600160000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdivByZero0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdivByZero0.json
@@ -1,0 +1,48 @@
+{
+    "sdivByZero0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdivByZero0Filler.json",
+            "sourceHash": "e28b1b8db741bfcec03b7cc8f52792aa153f3ae1967df90250790f1616e5ac03"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000600003600360000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172fe",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600003600360000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600003600360000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdivByZero1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdivByZero1.json
@@ -1,0 +1,48 @@
+{
+    "sdivByZero1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdivByZero1Filler.json",
+            "sourceHash": "24a3965ea6c53bf002f948f9011c6285484ffd0e223f2759fc15208277099d41"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdivByZero2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdivByZero2.json
@@ -1,0 +1,50 @@
+{
+    "sdivByZero2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdivByZero2Filler.json",
+            "sourceHash": "37ed1808a19210576d4855767d413bdd583bccb07c4546f0bd5a07c112e112cb"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600160007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffcf923bdff6000030501600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600160007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffcf923bdff6000030501600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600160007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffcf923bdff6000030501600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv_dejavu.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv_dejavu.json
@@ -1,0 +1,50 @@
+{
+    "sdiv_dejavu": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv_dejavuFiller.json",
+            "sourceHash": "9aa0a025d0f407c03982ce3cc06415063bc5a2b5672e0416880bf73057ad031c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600560096000030580600055",
+            "data": "0x",
+            "gas": "0x989680",
+            "gasPrice": "0x01",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x984849",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560096000030580600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600560096000030580600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min.json
@@ -1,0 +1,50 @@
+{
+    "sdiv_i256min": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv_i256minFiller.json",
+            "sourceHash": "e3608d44883226b06869f6e0166d5d3dbf6e57029344554f9d5358093087759c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016000037f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min2.json
@@ -1,0 +1,50 @@
+{
+    "sdiv_i256min2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv_i256min2Filler.json",
+            "sourceHash": "a5d9086646204003fb76b60436395730ac80703f96c5e72ff7d8d98103c2e893"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x8000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000305600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sdiv_i256min3.json
@@ -1,0 +1,48 @@
+{
+    "sdiv_i256min3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sdiv_i256min3Filler.json",
+            "sourceHash": "46cc6af8ec52711f15b64bdc3d967103128250f5adaf170c35b0d3ad576767a6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x01",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f2ea4",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6000037fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff05600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextendInvalidByteNumber.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextendInvalidByteNumber.json
@@ -1,0 +1,50 @@
+{
+    "signextendInvalidByteNumber": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextendInvalidByteNumberFiller.json",
+            "sourceHash": "bd7c7a0a6160f2edd405214bc7508e11cb967d1b5c361f31591ce474e537601a"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x62126af460500b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62126af460500b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x126af4"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62126af460500b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_00.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_00.json
@@ -1,0 +1,48 @@
+{
+    "signextend_00": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_00Filler.json",
+            "sourceHash": "e9b56b79cbe54b20c64488e6d90de2337ec046232a0235fdc59687e59ff450fe"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600060000b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f2eaa",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600060000b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600060000b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_0_BigByte.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_0_BigByte.json
@@ -1,0 +1,50 @@
+{
+    "signextend_0_BigByte": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_0_BigByteFiller.json",
+            "sourceHash": "743f6465e37f4cad183d1942bcb6c5571f52563665a601f15c3161219cf077f2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_AlmostBiggestByte.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_AlmostBiggestByte.json
@@ -1,0 +1,50 @@
+{
+    "signextend_AlmostBiggestByte": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_AlmostBiggestByteFiller.json",
+            "sourceHash": "46a327dbde6807687930463996a2f8ec9d13f420fe4bceddaea9e42c815172b1"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BigByteBigByte.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BigByteBigByte.json
@@ -1,0 +1,50 @@
+{
+    "signextend_BigByteBigByte": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BigByteBigByteFiller.json",
+            "sourceHash": "87bbe415e7942bf6f6f15b5afda46e1ddac938be49659c6dbe26c53b8553c55e"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BigBytePlus1_2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BigBytePlus1_2.json
@@ -1,0 +1,50 @@
+{
+    "signextend_BigBytePlus1_2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BigBytePlus1_2Filler.json",
+            "sourceHash": "3225e9faac70f37c4991cf62a12d7a9f042919be88279f738294f8acf33bb1bc"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60ff68f000000000000000010b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60ff68f000000000000000010b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60ff68f000000000000000010b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BigByte_0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BigByte_0.json
@@ -1,0 +1,48 @@
+{
+    "signextend_BigByte_0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BigByte_0Filler.json",
+            "sourceHash": "120aa893e304d547c61a4d40f6c43849b007283168be66354d37671b5bfa0bc6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f2eaa",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsNotSet.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsNotSet.json
@@ -1,0 +1,50 @@
+{
+    "signextend_BitIsNotSet": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BitIsNotSetFiller.json",
+            "sourceHash": "50d4836fd54ee2c47563c0570fb21fdd86ec9b33519d9629d4bbc27114500b26"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x62122f6a60000b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62122f6a60000b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x6a"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62122f6a60000b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsNotSetInHigherByte.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsNotSetInHigherByte.json
@@ -1,0 +1,50 @@
+{
+    "signextend_BitIsNotSetInHigherByte": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BitIsNotSetInHigherByteFiller.json",
+            "sourceHash": "66d23c7d6f4f5de80eef78e659f42293670b9daebf6e27a943ff59d5f6a0ff68"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x62126af460010b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62126af460010b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x6af4"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62126af460010b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsSetInHigherByte.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_BitIsSetInHigherByte.json
@@ -1,0 +1,50 @@
+{
+    "signextend_BitIsSetInHigherByte": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_BitIsSetInHigherByteFiller.json",
+            "sourceHash": "40c134de5e67c5c80fd84b0a51752f7c6caf67f69cd3ef53ef0227c9855b97ea"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6212faf460010b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6212faf460010b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffaf4"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6212faf460010b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_Overflow_dj42.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_Overflow_dj42.json
@@ -1,0 +1,48 @@
+{
+    "signextend_Overflow_dj42": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_Overflow_dj42Filler.json",
+            "sourceHash": "678af7c480fd91e0bb6817d429e54f7d8ecb7472a00426044274d198cf1d3a5c"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6005565b005b61800080680100000000000000010b6180011160035763badf000d601155",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0f4212",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6005565b005b61800080680100000000000000010b6180011160035763badf000d601155",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6005565b005b61800080680100000000000000010b6180011160035763badf000d601155",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_bigBytePlus1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_bigBytePlus1.json
@@ -1,0 +1,50 @@
+{
+    "signextend_bigBytePlus1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_bigBytePlus1Filler.json",
+            "sourceHash": "f50eb1e7742d093c60de5e2542801bf3d2517b5e94fbf9dd5b4b98df3426b342"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x66f000000000000161ffff0b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x66f000000000000161ffff0b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xf0000000000001"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x66f000000000000161ffff0b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/signextend_bitIsSet.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/signextend_bitIsSet.json
@@ -1,0 +1,50 @@
+{
+    "signextend_bitIsSet": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/signextend_bitIsSetFiller.json",
+            "sourceHash": "620712127f9d256bd412543fbb924e37f9dca791c5e48167c7e600e0808937bf"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x989680",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x62122ff460000b600055",
+            "data": "0x",
+            "gas": "0x0f4240",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0ef412",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62122ff460000b600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff4"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x62122ff460000b600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod0.json
@@ -1,0 +1,50 @@
+{
+    "smod0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod0Filler.json",
+            "sourceHash": "87a490316c59ef60600ee60523adbd69313f43f7d048df47cc7871e8b148726f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600003600560000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600003600560000307600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600003600560000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod1.json
@@ -1,0 +1,50 @@
+{
+    "smod1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod1Filler.json",
+            "sourceHash": "d0356031c6d7986562c221f58cfdb07b49e2383a8eb4ccbc428d7c6384555f2f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600003600507600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600003600507600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x02"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600003600507600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod2.json
@@ -1,0 +1,50 @@
+{
+    "smod2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod2Filler.json",
+            "sourceHash": "fecb36534ed3a9250654d0ba009e0b9abe4959b082b82baaada2528d857fffb4"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600560000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600560000307600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600560000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod3.json
@@ -1,0 +1,48 @@
+{
+    "smod3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod3Filler.json",
+            "sourceHash": "c4073e4d710ed200ec80a74b2dd7908ed4e3482df095e0c4c5e602cac463cbe2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600260000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600260000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600260000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod4.json
@@ -1,0 +1,48 @@
+{
+    "smod4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod4Filler.json",
+            "sourceHash": "8324aaabda50a007f1b13851c31420f97400a15e5e301ebcb37531fdbb4bf3d6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6000600260000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x017304",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600260000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6000600260000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod5.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod5.json
@@ -1,0 +1,48 @@
+{
+    "smod5": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod5Filler.json",
+            "sourceHash": "69328e21e14cf5a7cae1fe18ecef509f91d32723b5e24db951936a91b86b14ff"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+            "data": "0x",
+            "gas": "0x2710",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x1374",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod6.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod6.json
@@ -1,0 +1,50 @@
+{
+    "smod6": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod6Filler.json",
+            "sourceHash": "88bbf771632a648036ae497845bcd49c82368b8c08e9507fa93a7e3a7bd6f849"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x01386c",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod7.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod7.json
@@ -1,0 +1,48 @@
+{
+    "smod7": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod7Filler.json",
+            "sourceHash": "1efaba22ecff9e26ba73d28a02d1e7f4b94f94f93a72b2b61aa7bed270782d1f"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+            "data": "0x",
+            "gas": "0x2710",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x1374",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod8_byZero.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod8_byZero.json
@@ -1,0 +1,50 @@
+{
+    "smod8_byZero": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod8_byZeroFiller.json",
+            "sourceHash": "9ec6722c583c01ca9390edddeb8c4c70f88feaa99f80d53ee3eddaa01a52b26e"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600d600060c86000030703600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013866",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d600060c86000030703600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600d600060c86000030703600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod_i256min1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod_i256min1.json
@@ -1,0 +1,48 @@
+{
+    "smod_i256min1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod_i256min1Filler.json",
+            "sourceHash": "30a7b7e551dfcca22098bfc8ad01f19c5e88af9b264c63f6aa73c4e396d167bc"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000307600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0172fe",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60016000037f800000000000000000000000000000000000000000000000000000000000000060000307600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/smod_i256min2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/smod_i256min2.json
@@ -1,0 +1,50 @@
+{
+    "smod_i256min2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/smod_i256min2Filler.json",
+            "sourceHash": "c2b3f8a237a292011cb91fa389785a62bc6995fcb32852420864fd97545933e6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x600160016000037f80000000000000000000000000000000000000000000000000000000000000006000030703600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013860",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600160016000037f80000000000000000000000000000000000000000000000000000000000000006000030703600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x600160016000037f80000000000000000000000000000000000000000000000000000000000000006000030703600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/stop.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/stop.json
@@ -1,0 +1,48 @@
+{
+    "stop": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/stopFiller.json",
+            "sourceHash": "f9c02b25d8205a035f4043b30cd5def28c3f1151b3d1f7fea04206c514e21742"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x00",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x0186a0",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x00",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x00",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sub0.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sub0.json
@@ -1,0 +1,50 @@
+{
+    "sub0": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sub0Filler.json",
+            "sourceHash": "4bb8ac5e46af011508a8fc613f66b01f68a79c359c431b8e6ea67f45aa5cb2b6"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6001601703600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001601703600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x16"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6001601703600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sub1.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sub1.json
@@ -1,0 +1,50 @@
+{
+    "sub1": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sub1Filler.json",
+            "sourceHash": "3857cc93756d1ac10073b627f878d1d8002d52b66615efc3da199dafb2e30883"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6003600203600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600203600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6003600203600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sub2.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sub2.json
@@ -1,0 +1,50 @@
+{
+    "sub2": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sub2Filler.json",
+            "sourceHash": "f6dc398e416318b4ee4d593de828814df2a797875004f923fefaba5b331e0791"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x6017600003600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6017600003600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe9"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x6017600003600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sub3.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sub3.json
@@ -1,0 +1,50 @@
+{
+    "sub3": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sub3Filler.json",
+            "sourceHash": "5e07fd6711ac4525704e5efcb859ddb65c1a6c28bbc0655235b1fd9fb1bf1669"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600003600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600003600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0x01"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600003600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/res/VMTests/vmArithmeticTest/sub4.json
+++ b/jsontests/res/VMTests/vmArithmeticTest/sub4.json
@@ -1,0 +1,50 @@
+{
+    "sub4": {
+        "_info": {
+            "comment": "",
+            "filledwith": "testeth 1.4.0.dev0-56+commit.71414ae3",
+            "lllcversion": "Version: 0.4.25-develop.2018.5.30+commit.0a1a8bfb.Linux.g++",
+            "source": "src/VMTestsFiller/vmArithmeticTest/sub4Filler.json",
+            "sourceHash": "35cc66e9fd0f77a437566e84a0bc19e148d3f1004b3f9ba91a4aeeb0e8f051c2"
+        },
+        "callcreates": [],
+        "env": {
+            "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty": "0x0100",
+            "currentGasLimit": "0x0f4240",
+            "currentNumber": "0x00",
+            "currentTimestamp": "0x01"
+        },
+        "exec": {
+            "address": "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff03600055",
+            "data": "0x",
+            "gas": "0x0186a0",
+            "gasPrice": "0x5af3107a4000",
+            "origin": "0xcd1722f2947def4cf144679da39c4c32bdc35681",
+            "value": "0x0de0b6b3a7640000"
+        },
+        "gas": "0x013874",
+        "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out": "0x",
+        "post": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff03600055",
+                "nonce": "0x00",
+                "storage": {
+                    "0x00": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                }
+            }
+        },
+        "pre": {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6": {
+                "balance": "0x0de0b6b3a7640000",
+                "code": "0x60007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff03600055",
+                "nonce": "0x00",
+                "storage": {}
+            }
+        }
+    }
+}

--- a/jsontests/tests/arithmetic.rs
+++ b/jsontests/tests/arithmetic.rs
@@ -2,209 +2,24 @@
 
 extern crate jsontests;
 extern crate serde_json;
-#[macro_use]
-extern crate lazy_static;
+use std::fs::File;
+use std::io::Read;
+use std::collections::HashMap;
+use std::fs;
 
-use serde_json::Value;
 use jsontests::test_transaction;
 
-lazy_static! {
-    static ref TESTS: Value =
-        serde_json::from_str(include_str!("../res/files/vmArithmeticTest.json")).unwrap();
+#[test]
+fn vmArithTest() {
+    let paths = fs::read_dir("./res/VMTests/vmArithmeticTest").unwrap();
+    for path in paths {
+        let mut file = File::open(path.unwrap().path()).unwrap();
+        let mut data = String::new();
+        file.read_to_string(&mut data).unwrap();
+        let test_data: HashMap<String, serde_json::Value> = serde_json::from_str(&*data).unwrap();
+        for (opcode, test_datum) in test_data.iter() {
+            println!("opcode: {}", opcode);
+            assert_eq!(test_transaction(opcode, test_datum, true), true);
+        }
+    }
 }
-
-#[test] fn add0() { assert_eq!(test_transaction("add0", &TESTS["add0"], true), true); }
-#[test] fn add1() { assert_eq!(test_transaction("add1", &TESTS["add1"], true), true); }
-#[test] fn add2() { assert_eq!(test_transaction("add2", &TESTS["add2"], true), true); }
-#[test] fn add3() { assert_eq!(test_transaction("add3", &TESTS["add3"], true), true); }
-#[test] fn add4() { assert_eq!(test_transaction("add4", &TESTS["add4"], true), true); }
-#[test] fn addmod0() { assert_eq!(test_transaction("addmod0", &TESTS["addmod0"], true), true); }
-#[test] fn addmod1() { assert_eq!(test_transaction("addmod1", &TESTS["addmod1"], true), true); }
-#[test] fn addmod1_overflow2() { assert_eq!(test_transaction("addmod1_overflow2", &TESTS["addmod1_overflow2"], true), true); }
-#[test] fn addmod1_overflow3() { assert_eq!(test_transaction("addmod1_overflow3", &TESTS["addmod1_overflow3"], true), true); }
-#[test] fn addmod1_overflow4() { assert_eq!(test_transaction("addmod1_overflow4", &TESTS["addmod1_overflow4"], true), true); }
-#[test] fn addmod1_overflowDiff() { assert_eq!(test_transaction("addmod1_overflowDiff", &TESTS["addmod1_overflowDiff"], true), true); }
-#[test] fn addmod2() { assert_eq!(test_transaction("addmod2", &TESTS["addmod2"], true), true); }
-#[test] fn addmod2_0() { assert_eq!(test_transaction("addmod2_0", &TESTS["addmod2_0"], true), true); }
-#[test] fn addmod2_1() { assert_eq!(test_transaction("addmod2_1", &TESTS["addmod2_1"], true), true); }
-#[test] fn addmod3() { assert_eq!(test_transaction("addmod3", &TESTS["addmod3"], true), true); }
-#[test] fn addmod3_0() { assert_eq!(test_transaction("addmod3_0", &TESTS["addmod3_0"], true), true); }
-#[test] fn addmodBigIntCast() { assert_eq!(test_transaction("addmodBigIntCast", &TESTS["addmodBigIntCast"], true), true); }
-#[test] fn addmodDivByZero() { assert_eq!(test_transaction("addmodDivByZero", &TESTS["addmodDivByZero"], true), true); }
-#[test] fn addmodDivByZero1() { assert_eq!(test_transaction("addmodDivByZero1", &TESTS["addmodDivByZero1"], true), true); }
-#[test] fn addmodDivByZero2() { assert_eq!(test_transaction("addmodDivByZero2", &TESTS["addmodDivByZero2"], true), true); }
-#[test] fn addmodDivByZero3() { assert_eq!(test_transaction("addmodDivByZero3", &TESTS["addmodDivByZero3"], true), true); }
-#[test] fn arith1() { assert_eq!(test_transaction("arith1", &TESTS["arith1"], true), true); }
-#[test] fn div1() { assert_eq!(test_transaction("div1", &TESTS["div1"], true), true); }
-#[test] fn divBoostBug() { assert_eq!(test_transaction("divBoostBug", &TESTS["divBoostBug"], true), true); }
-#[test] fn divByNonZero0() { assert_eq!(test_transaction("divByNonZero0", &TESTS["divByNonZero0"], true), true); }
-#[test] fn divByNonZero1() { assert_eq!(test_transaction("divByNonZero1", &TESTS["divByNonZero1"], true), true); }
-#[test] fn divByNonZero2() { assert_eq!(test_transaction("divByNonZero2", &TESTS["divByNonZero2"], true), true); }
-#[test] fn divByNonZero3() { assert_eq!(test_transaction("divByNonZero3", &TESTS["divByNonZero3"], true), true); }
-#[test] fn divByZero() { assert_eq!(test_transaction("divByZero", &TESTS["divByZero"], true), true); }
-#[test] fn divByZero_2() { assert_eq!(test_transaction("divByZero_2", &TESTS["divByZero_2"], true), true); }
-#[test] fn exp0() { assert_eq!(test_transaction("exp0", &TESTS["exp0"], true), true); }
-#[test] fn exp1() { assert_eq!(test_transaction("exp1", &TESTS["exp1"], true), true); }
-#[test] fn exp2() { assert_eq!(test_transaction("exp2", &TESTS["exp2"], true), true); }
-#[test] fn exp3() { assert_eq!(test_transaction("exp3", &TESTS["exp3"], true), true); }
-#[test] fn exp4() { assert_eq!(test_transaction("exp4", &TESTS["exp4"], true), true); }
-#[test] fn exp5() { assert_eq!(test_transaction("exp5", &TESTS["exp5"], true), true); }
-#[test] fn exp6() { assert_eq!(test_transaction("exp6", &TESTS["exp6"], true), true); }
-#[test] fn exp7() { assert_eq!(test_transaction("exp7", &TESTS["exp7"], true), true); }
-#[test] fn expPowerOf256Of256_0() { assert_eq!(test_transaction("expPowerOf256Of256_0", &TESTS["expPowerOf256Of256_0"], true), true); }
-#[test] fn expPowerOf256Of256_1() { assert_eq!(test_transaction("expPowerOf256Of256_1", &TESTS["expPowerOf256Of256_1"], true), true); }
-#[test] fn expPowerOf256Of256_10() { assert_eq!(test_transaction("expPowerOf256Of256_10", &TESTS["expPowerOf256Of256_10"], true), true); }
-#[test] fn expPowerOf256Of256_11() { assert_eq!(test_transaction("expPowerOf256Of256_11", &TESTS["expPowerOf256Of256_11"], true), true); }
-#[test] fn expPowerOf256Of256_12() { assert_eq!(test_transaction("expPowerOf256Of256_12", &TESTS["expPowerOf256Of256_12"], true), true); }
-#[test] fn expPowerOf256Of256_13() { assert_eq!(test_transaction("expPowerOf256Of256_13", &TESTS["expPowerOf256Of256_13"], true), true); }
-#[test] fn expPowerOf256Of256_14() { assert_eq!(test_transaction("expPowerOf256Of256_14", &TESTS["expPowerOf256Of256_14"], true), true); }
-#[test] fn expPowerOf256Of256_15() { assert_eq!(test_transaction("expPowerOf256Of256_15", &TESTS["expPowerOf256Of256_15"], true), true); }
-#[test] fn expPowerOf256Of256_16() { assert_eq!(test_transaction("expPowerOf256Of256_16", &TESTS["expPowerOf256Of256_16"], true), true); }
-#[test] fn expPowerOf256Of256_17() { assert_eq!(test_transaction("expPowerOf256Of256_17", &TESTS["expPowerOf256Of256_17"], true), true); }
-#[test] fn expPowerOf256Of256_18() { assert_eq!(test_transaction("expPowerOf256Of256_18", &TESTS["expPowerOf256Of256_18"], true), true); }
-#[test] fn expPowerOf256Of256_19() { assert_eq!(test_transaction("expPowerOf256Of256_19", &TESTS["expPowerOf256Of256_19"], true), true); }
-#[test] fn expPowerOf256Of256_2() { assert_eq!(test_transaction("expPowerOf256Of256_2", &TESTS["expPowerOf256Of256_2"], true), true); }
-#[test] fn expPowerOf256Of256_20() { assert_eq!(test_transaction("expPowerOf256Of256_20", &TESTS["expPowerOf256Of256_20"], true), true); }
-#[test] fn expPowerOf256Of256_21() { assert_eq!(test_transaction("expPowerOf256Of256_21", &TESTS["expPowerOf256Of256_21"], true), true); }
-#[test] fn expPowerOf256Of256_22() { assert_eq!(test_transaction("expPowerOf256Of256_22", &TESTS["expPowerOf256Of256_22"], true), true); }
-#[test] fn expPowerOf256Of256_23() { assert_eq!(test_transaction("expPowerOf256Of256_23", &TESTS["expPowerOf256Of256_23"], true), true); }
-#[test] fn expPowerOf256Of256_24() { assert_eq!(test_transaction("expPowerOf256Of256_24", &TESTS["expPowerOf256Of256_24"], true), true); }
-#[test] fn expPowerOf256Of256_25() { assert_eq!(test_transaction("expPowerOf256Of256_25", &TESTS["expPowerOf256Of256_25"], true), true); }
-#[test] fn expPowerOf256Of256_26() { assert_eq!(test_transaction("expPowerOf256Of256_26", &TESTS["expPowerOf256Of256_26"], true), true); }
-#[test] fn expPowerOf256Of256_27() { assert_eq!(test_transaction("expPowerOf256Of256_27", &TESTS["expPowerOf256Of256_27"], true), true); }
-#[test] fn expPowerOf256Of256_28() { assert_eq!(test_transaction("expPowerOf256Of256_28", &TESTS["expPowerOf256Of256_28"], true), true); }
-#[test] fn expPowerOf256Of256_29() { assert_eq!(test_transaction("expPowerOf256Of256_29", &TESTS["expPowerOf256Of256_29"], true), true); }
-#[test] fn expPowerOf256Of256_3() { assert_eq!(test_transaction("expPowerOf256Of256_3", &TESTS["expPowerOf256Of256_3"], true), true); }
-#[test] fn expPowerOf256Of256_30() { assert_eq!(test_transaction("expPowerOf256Of256_30", &TESTS["expPowerOf256Of256_30"], true), true); }
-#[test] fn expPowerOf256Of256_31() { assert_eq!(test_transaction("expPowerOf256Of256_31", &TESTS["expPowerOf256Of256_31"], true), true); }
-#[test] fn expPowerOf256Of256_32() { assert_eq!(test_transaction("expPowerOf256Of256_32", &TESTS["expPowerOf256Of256_32"], true), true); }
-#[test] fn expPowerOf256Of256_33() { assert_eq!(test_transaction("expPowerOf256Of256_33", &TESTS["expPowerOf256Of256_33"], true), true); }
-#[test] fn expPowerOf256Of256_4() { assert_eq!(test_transaction("expPowerOf256Of256_4", &TESTS["expPowerOf256Of256_4"], true), true); }
-#[test] fn expPowerOf256Of256_5() { assert_eq!(test_transaction("expPowerOf256Of256_5", &TESTS["expPowerOf256Of256_5"], true), true); }
-#[test] fn expPowerOf256Of256_6() { assert_eq!(test_transaction("expPowerOf256Of256_6", &TESTS["expPowerOf256Of256_6"], true), true); }
-#[test] fn expPowerOf256Of256_7() { assert_eq!(test_transaction("expPowerOf256Of256_7", &TESTS["expPowerOf256Of256_7"], true), true); }
-#[test] fn expPowerOf256Of256_8() { assert_eq!(test_transaction("expPowerOf256Of256_8", &TESTS["expPowerOf256Of256_8"], true), true); }
-#[test] fn expPowerOf256Of256_9() { assert_eq!(test_transaction("expPowerOf256Of256_9", &TESTS["expPowerOf256Of256_9"], true), true); }
-#[test] fn expPowerOf256_1() { assert_eq!(test_transaction("expPowerOf256_1", &TESTS["expPowerOf256_1"], true), true); }
-#[test] fn expPowerOf256_10() { assert_eq!(test_transaction("expPowerOf256_10", &TESTS["expPowerOf256_10"], true), true); }
-#[test] fn expPowerOf256_11() { assert_eq!(test_transaction("expPowerOf256_11", &TESTS["expPowerOf256_11"], true), true); }
-#[test] fn expPowerOf256_12() { assert_eq!(test_transaction("expPowerOf256_12", &TESTS["expPowerOf256_12"], true), true); }
-#[test] fn expPowerOf256_13() { assert_eq!(test_transaction("expPowerOf256_13", &TESTS["expPowerOf256_13"], true), true); }
-#[test] fn expPowerOf256_14() { assert_eq!(test_transaction("expPowerOf256_14", &TESTS["expPowerOf256_14"], true), true); }
-#[test] fn expPowerOf256_15() { assert_eq!(test_transaction("expPowerOf256_15", &TESTS["expPowerOf256_15"], true), true); }
-#[test] fn expPowerOf256_16() { assert_eq!(test_transaction("expPowerOf256_16", &TESTS["expPowerOf256_16"], true), true); }
-#[test] fn expPowerOf256_17() { assert_eq!(test_transaction("expPowerOf256_17", &TESTS["expPowerOf256_17"], true), true); }
-#[test] fn expPowerOf256_18() { assert_eq!(test_transaction("expPowerOf256_18", &TESTS["expPowerOf256_18"], true), true); }
-#[test] fn expPowerOf256_19() { assert_eq!(test_transaction("expPowerOf256_19", &TESTS["expPowerOf256_19"], true), true); }
-#[test] fn expPowerOf256_2() { assert_eq!(test_transaction("expPowerOf256_2", &TESTS["expPowerOf256_2"], true), true); }
-#[test] fn expPowerOf256_20() { assert_eq!(test_transaction("expPowerOf256_20", &TESTS["expPowerOf256_20"], true), true); }
-#[test] fn expPowerOf256_21() { assert_eq!(test_transaction("expPowerOf256_21", &TESTS["expPowerOf256_21"], true), true); }
-#[test] fn expPowerOf256_22() { assert_eq!(test_transaction("expPowerOf256_22", &TESTS["expPowerOf256_22"], true), true); }
-#[test] fn expPowerOf256_23() { assert_eq!(test_transaction("expPowerOf256_23", &TESTS["expPowerOf256_23"], true), true); }
-#[test] fn expPowerOf256_24() { assert_eq!(test_transaction("expPowerOf256_24", &TESTS["expPowerOf256_24"], true), true); }
-#[test] fn expPowerOf256_25() { assert_eq!(test_transaction("expPowerOf256_25", &TESTS["expPowerOf256_25"], true), true); }
-#[test] fn expPowerOf256_26() { assert_eq!(test_transaction("expPowerOf256_26", &TESTS["expPowerOf256_26"], true), true); }
-#[test] fn expPowerOf256_27() { assert_eq!(test_transaction("expPowerOf256_27", &TESTS["expPowerOf256_27"], true), true); }
-#[test] fn expPowerOf256_28() { assert_eq!(test_transaction("expPowerOf256_28", &TESTS["expPowerOf256_28"], true), true); }
-#[test] fn expPowerOf256_29() { assert_eq!(test_transaction("expPowerOf256_29", &TESTS["expPowerOf256_29"], true), true); }
-#[test] fn expPowerOf256_3() { assert_eq!(test_transaction("expPowerOf256_3", &TESTS["expPowerOf256_3"], true), true); }
-#[test] fn expPowerOf256_30() { assert_eq!(test_transaction("expPowerOf256_30", &TESTS["expPowerOf256_30"], true), true); }
-#[test] fn expPowerOf256_31() { assert_eq!(test_transaction("expPowerOf256_31", &TESTS["expPowerOf256_31"], true), true); }
-#[test] fn expPowerOf256_32() { assert_eq!(test_transaction("expPowerOf256_32", &TESTS["expPowerOf256_32"], true), true); }
-#[test] fn expPowerOf256_33() { assert_eq!(test_transaction("expPowerOf256_33", &TESTS["expPowerOf256_33"], true), true); }
-#[test] fn expPowerOf256_4() { assert_eq!(test_transaction("expPowerOf256_4", &TESTS["expPowerOf256_4"], true), true); }
-#[test] fn expPowerOf256_5() { assert_eq!(test_transaction("expPowerOf256_5", &TESTS["expPowerOf256_5"], true), true); }
-#[test] fn expPowerOf256_6() { assert_eq!(test_transaction("expPowerOf256_6", &TESTS["expPowerOf256_6"], true), true); }
-#[test] fn expPowerOf256_7() { assert_eq!(test_transaction("expPowerOf256_7", &TESTS["expPowerOf256_7"], true), true); }
-#[test] fn expPowerOf256_8() { assert_eq!(test_transaction("expPowerOf256_8", &TESTS["expPowerOf256_8"], true), true); }
-#[test] fn expPowerOf256_9() { assert_eq!(test_transaction("expPowerOf256_9", &TESTS["expPowerOf256_9"], true), true); }
-#[test] fn expPowerOf2_128() { assert_eq!(test_transaction("expPowerOf2_128", &TESTS["expPowerOf2_128"], true), true); }
-#[test] fn expPowerOf2_16() { assert_eq!(test_transaction("expPowerOf2_16", &TESTS["expPowerOf2_16"], true), true); }
-#[test] fn expPowerOf2_2() { assert_eq!(test_transaction("expPowerOf2_2", &TESTS["expPowerOf2_2"], true), true); }
-#[test] fn expPowerOf2_256() { assert_eq!(test_transaction("expPowerOf2_256", &TESTS["expPowerOf2_256"], true), true); }
-#[test] fn expPowerOf2_32() { assert_eq!(test_transaction("expPowerOf2_32", &TESTS["expPowerOf2_32"], true), true); }
-#[test] fn expPowerOf2_4() { assert_eq!(test_transaction("expPowerOf2_4", &TESTS["expPowerOf2_4"], true), true); }
-#[test] fn expPowerOf2_64() { assert_eq!(test_transaction("expPowerOf2_64", &TESTS["expPowerOf2_64"], true), true); }
-#[test] fn expPowerOf2_8() { assert_eq!(test_transaction("expPowerOf2_8", &TESTS["expPowerOf2_8"], true), true); }
-#[test] fn expXY() { assert_eq!(test_transaction("expXY", &TESTS["expXY"], true), true); }
-#[test] fn expXY_success() { assert_eq!(test_transaction("expXY_success", &TESTS["expXY_success"], true), true); }
-#[test] fn fibbonacci_unrolled() { assert_eq!(test_transaction("fibbonacci_unrolled", &TESTS["fibbonacci_unrolled"], true), true); }
-#[test] fn mod0() { assert_eq!(test_transaction("mod0", &TESTS["mod0"], true), true); }
-#[test] fn mod1() { assert_eq!(test_transaction("mod1", &TESTS["mod1"], true), true); }
-#[test] fn mod2() { assert_eq!(test_transaction("mod2", &TESTS["mod2"], true), true); }
-#[test] fn mod3() { assert_eq!(test_transaction("mod3", &TESTS["mod3"], true), true); }
-#[test] fn mod4() { assert_eq!(test_transaction("mod4", &TESTS["mod4"], true), true); }
-#[test] fn modByZero() { assert_eq!(test_transaction("modByZero", &TESTS["modByZero"], true), true); }
-#[test] fn mul0() { assert_eq!(test_transaction("mul0", &TESTS["mul0"], true), true); }
-#[test] fn mul1() { assert_eq!(test_transaction("mul1", &TESTS["mul1"], true), true); }
-#[test] fn mul2() { assert_eq!(test_transaction("mul2", &TESTS["mul2"], true), true); }
-#[test] fn mul3() { assert_eq!(test_transaction("mul3", &TESTS["mul3"], true), true); }
-#[test] fn mul4() { assert_eq!(test_transaction("mul4", &TESTS["mul4"], true), true); }
-#[test] fn mul5() { assert_eq!(test_transaction("mul5", &TESTS["mul5"], true), true); }
-#[test] fn mul6() { assert_eq!(test_transaction("mul6", &TESTS["mul6"], true), true); }
-#[test] fn mul7() { assert_eq!(test_transaction("mul7", &TESTS["mul7"], true), true); }
-#[test] fn mulUnderFlow() { assert_eq!(test_transaction("mulUnderFlow", &TESTS["mulUnderFlow"], true), true); }
-#[test] fn mulmod0() { assert_eq!(test_transaction("mulmod0", &TESTS["mulmod0"], true), true); }
-#[test] fn mulmod1() { assert_eq!(test_transaction("mulmod1", &TESTS["mulmod1"], true), true); }
-#[test] fn mulmod1_overflow() { assert_eq!(test_transaction("mulmod1_overflow", &TESTS["mulmod1_overflow"], true), true); }
-#[test] fn mulmod1_overflow2() { assert_eq!(test_transaction("mulmod1_overflow2", &TESTS["mulmod1_overflow2"], true), true); }
-#[test] fn mulmod1_overflow3() { assert_eq!(test_transaction("mulmod1_overflow3", &TESTS["mulmod1_overflow3"], true), true); }
-#[test] fn mulmod1_overflow4() { assert_eq!(test_transaction("mulmod1_overflow4", &TESTS["mulmod1_overflow4"], true), true); }
-#[test] fn mulmod2() { assert_eq!(test_transaction("mulmod2", &TESTS["mulmod2"], true), true); }
-#[test] fn mulmod2_0() { assert_eq!(test_transaction("mulmod2_0", &TESTS["mulmod2_0"], true), true); }
-#[test] fn mulmod2_1() { assert_eq!(test_transaction("mulmod2_1", &TESTS["mulmod2_1"], true), true); }
-#[test] fn mulmod3() { assert_eq!(test_transaction("mulmod3", &TESTS["mulmod3"], true), true); }
-#[test] fn mulmod3_0() { assert_eq!(test_transaction("mulmod3_0", &TESTS["mulmod3_0"], true), true); }
-#[test] fn mulmod4() { assert_eq!(test_transaction("mulmod4", &TESTS["mulmod4"], true), true); }
-#[test] fn mulmoddivByZero() { assert_eq!(test_transaction("mulmoddivByZero", &TESTS["mulmoddivByZero"], true), true); }
-#[test] fn mulmoddivByZero1() { assert_eq!(test_transaction("mulmoddivByZero1", &TESTS["mulmoddivByZero1"], true), true); }
-#[test] fn mulmoddivByZero2() { assert_eq!(test_transaction("mulmoddivByZero2", &TESTS["mulmoddivByZero2"], true), true); }
-#[test] fn mulmoddivByZero3() { assert_eq!(test_transaction("mulmoddivByZero3", &TESTS["mulmoddivByZero3"], true), true); }
-#[test] fn not1() { assert_eq!(test_transaction("not1", &TESTS["not1"], true), true); }
-#[test] fn sdiv0() { assert_eq!(test_transaction("sdiv0", &TESTS["sdiv0"], true), true); }
-#[test] fn sdiv1() { assert_eq!(test_transaction("sdiv1", &TESTS["sdiv1"], true), true); }
-#[test] fn sdiv2() { assert_eq!(test_transaction("sdiv2", &TESTS["sdiv2"], true), true); }
-#[test] fn sdiv3() { assert_eq!(test_transaction("sdiv3", &TESTS["sdiv3"], true), true); }
-#[test] fn sdiv4() { assert_eq!(test_transaction("sdiv4", &TESTS["sdiv4"], true), true); }
-#[test] fn sdiv5() { assert_eq!(test_transaction("sdiv5", &TESTS["sdiv5"], true), true); }
-#[test] fn sdiv6() { assert_eq!(test_transaction("sdiv6", &TESTS["sdiv6"], true), true); }
-#[test] fn sdiv7() { assert_eq!(test_transaction("sdiv7", &TESTS["sdiv7"], true), true); }
-#[test] fn sdiv8() { assert_eq!(test_transaction("sdiv8", &TESTS["sdiv8"], true), true); }
-#[test] fn sdiv9() { assert_eq!(test_transaction("sdiv9", &TESTS["sdiv9"], true), true); }
-#[test] fn sdivByZero0() { assert_eq!(test_transaction("sdivByZero0", &TESTS["sdivByZero0"], true), true); }
-#[test] fn sdivByZero1() { assert_eq!(test_transaction("sdivByZero1", &TESTS["sdivByZero1"], true), true); }
-#[test] fn sdivByZero2() { assert_eq!(test_transaction("sdivByZero2", &TESTS["sdivByZero2"], true), true); }
-#[test] fn sdiv_dejavu() { assert_eq!(test_transaction("sdiv_dejavu", &TESTS["sdiv_dejavu"], true), true); }
-#[test] fn sdiv_i256min() { assert_eq!(test_transaction("sdiv_i256min", &TESTS["sdiv_i256min"], true), true); }
-#[test] fn sdiv_i256min2() { assert_eq!(test_transaction("sdiv_i256min2", &TESTS["sdiv_i256min2"], true), true); }
-#[test] fn sdiv_i256min3() { assert_eq!(test_transaction("sdiv_i256min3", &TESTS["sdiv_i256min3"], true), true); }
-#[test] fn signextendInvalidByteNumber() { assert_eq!(test_transaction("signextendInvalidByteNumber", &TESTS["signextendInvalidByteNumber"], true), true); }
-#[test] fn signextend_00() { assert_eq!(test_transaction("signextend_00", &TESTS["signextend_00"], true), true); }
-#[test] fn signextend_0_BigByte() { assert_eq!(test_transaction("signextend_0_BigByte", &TESTS["signextend_0_BigByte"], true), true); }
-#[test] fn signextend_AlmostBiggestByte() { assert_eq!(test_transaction("signextend_AlmostBiggestByte", &TESTS["signextend_AlmostBiggestByte"], true), true); }
-#[test] fn signextend_BigByteBigByte() { assert_eq!(test_transaction("signextend_BigByteBigByte", &TESTS["signextend_BigByteBigByte"], true), true); }
-#[test] fn signextend_BigBytePlus1_2() { assert_eq!(test_transaction("signextend_BigBytePlus1_2", &TESTS["signextend_BigBytePlus1_2"], true), true); }
-#[test] fn signextend_BigByte_0() { assert_eq!(test_transaction("signextend_BigByte_0", &TESTS["signextend_BigByte_0"], true), true); }
-#[test] fn signextend_BitIsNotSet() { assert_eq!(test_transaction("signextend_BitIsNotSet", &TESTS["signextend_BitIsNotSet"], true), true); }
-#[test] fn signextend_BitIsNotSetInHigherByte() { assert_eq!(test_transaction("signextend_BitIsNotSetInHigherByte", &TESTS["signextend_BitIsNotSetInHigherByte"], true), true); }
-#[test] fn signextend_BitIsSetInHigherByte() { assert_eq!(test_transaction("signextend_BitIsSetInHigherByte", &TESTS["signextend_BitIsSetInHigherByte"], true), true); }
-#[test] fn signextend_Overflow_dj42() { assert_eq!(test_transaction("signextend_Overflow_dj42", &TESTS["signextend_Overflow_dj42"], true), true); }
-#[test] fn signextend_bigBytePlus1() { assert_eq!(test_transaction("signextend_bigBytePlus1", &TESTS["signextend_bigBytePlus1"], true), true); }
-#[test] fn signextend_bitIsSet() { assert_eq!(test_transaction("signextend_bitIsSet", &TESTS["signextend_bitIsSet"], true), true); }
-#[test] fn smod0() { assert_eq!(test_transaction("smod0", &TESTS["smod0"], true), true); }
-#[test] fn smod1() { assert_eq!(test_transaction("smod1", &TESTS["smod1"], true), true); }
-#[test] fn smod2() { assert_eq!(test_transaction("smod2", &TESTS["smod2"], true), true); }
-#[test] fn smod3() { assert_eq!(test_transaction("smod3", &TESTS["smod3"], true), true); }
-#[test] fn smod4() { assert_eq!(test_transaction("smod4", &TESTS["smod4"], true), true); }
-#[test] fn smod5() { assert_eq!(test_transaction("smod5", &TESTS["smod5"], true), true); }
-#[test] fn smod6() { assert_eq!(test_transaction("smod6", &TESTS["smod6"], true), true); }
-#[test] fn smod7() { assert_eq!(test_transaction("smod7", &TESTS["smod7"], true), true); }
-#[test] fn smod8_byZero() { assert_eq!(test_transaction("smod8_byZero", &TESTS["smod8_byZero"], true), true); }
-#[test] fn smod_i256min1() { assert_eq!(test_transaction("smod_i256min1", &TESTS["smod_i256min1"], true), true); }
-#[test] fn smod_i256min2() { assert_eq!(test_transaction("smod_i256min2", &TESTS["smod_i256min2"], true), true); }
-#[test] fn stop() { assert_eq!(test_transaction("stop", &TESTS["stop"], true), true); }
-#[test] fn sub0() { assert_eq!(test_transaction("sub0", &TESTS["sub0"], true), true); }
-#[test] fn sub1() { assert_eq!(test_transaction("sub1", &TESTS["sub1"], true), true); }
-#[test] fn sub2() { assert_eq!(test_transaction("sub2", &TESTS["sub2"], true), true); }
-#[test] fn sub3() { assert_eq!(test_transaction("sub3", &TESTS["sub3"], true), true); }
-#[test] fn sub4() { assert_eq!(test_transaction("sub4", &TESTS["sub4"], true), true); }


### PR DESCRIPTION
Right now we've only replaced vmArithmeticTests.

Down the ine, instead of copying the Ethereum tests, it could be linked to in some other way such as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)