### PR TITLE
add CALLCODE in CALL branch of gas calculation match expression

### DIFF
--- a/src/eval/cost.rs
+++ b/src/eval/cost.rs
@@ -140,7 +140,7 @@ pub fn memory_cost<M: Memory + Default, P: Patch>(instruction: Instruction, stat
             let len: U256 = stack.peek(2).unwrap().into();
             memory_expand(current, Gas::from(from), Gas::from(len))
         },
-        Instruction::CALL => {
+        Instruction::CALL | Instruction::CALLCODE => {
             let in_from: U256 = stack.peek(3).unwrap().into();
             let in_len: U256 = stack.peek(4).unwrap().into();
             let out_from: U256 = stack.peek(5).unwrap().into();


### PR DESCRIPTION
Fixing the gas calculation bug caused 11 `InputLimitsLight` tests to fail.

This change reflects the behavior of the `geth` vm in this case: 

https://github.com/ethereumproject/go-ethereum/blob/76ac6665e47e1e8a115cfa3c3c0281a337cef418/core/vm/vm.go#L323