### PR TITLE
network::classic features passthrough

### DIFF
--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -7,5 +7,12 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1"]
+std = ["sputnikvm/std"]


### PR DESCRIPTION
As patches were moved to separate crates, it's expected to use them now to import `Patch` implementations for different networks.

Although, sputnikvm defines a set of compile-time feature flags that are used, for instance, in `sputnikvm-ffi` for geth. Since now `sputnikvm-ffi` needs to also import `classic network` crate, we need to compile the `sputnikvm` dependency of the `network` crate with the same features as we do compile main `sputnikvm` dependency.

So in the end of the day we need to pass the features through the `network` crate, so we would not end up with code duplication from one dependency being built in different configurations.