### PR TITLE
Clippy-based refactoring

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -42,8 +42,8 @@ fn handle_step_without_rpc(vm: &mut VM) {
         },
         Err(RequireError::AccountStorage(address, index)) => {
             vm.commit_account(AccountCommitment::Storage {
-                address: address,
-                index: index,
+                address,
+                index,
                 value: M256::zero(),
             }).unwrap();
         },
@@ -80,8 +80,8 @@ fn handle_fire_without_rpc(vm: &mut VM) {
             },
             Err(RequireError::AccountStorage(address, index)) => {
                 vm.commit_account(AccountCommitment::Storage {
-                    address: address,
-                    index: index,
+                    address,
+                    index,
                     value: M256::zero(),
                 }).unwrap();
             },
@@ -110,9 +110,9 @@ fn handle_fire_with_rpc<T: GethRPCClient>(client: &mut T, vm: &mut VM, block_num
                     vm.commit_account(AccountCommitment::Nonexist(address)).unwrap();
                 } else {
                     vm.commit_account(AccountCommitment::Full {
-                        nonce: nonce,
-                        address: address,
-                        balance: balance,
+                        nonce,
+                        address,
+                        balance,
                         code: Rc::new(code),
                     }).unwrap();
                 }
@@ -122,16 +122,16 @@ fn handle_fire_with_rpc<T: GethRPCClient>(client: &mut T, vm: &mut VM, block_num
                                                                   &format!("0x{:x}", index),
                                                                   &block_number)).unwrap();
                 vm.commit_account(AccountCommitment::Storage {
-                    address: address,
-                    index: index,
-                    value: value,
+                    address,
+                    index,
+                    value,
                 }).unwrap();
             },
             Err(RequireError::AccountCode(address)) => {
                 let code = read_hex(&client.get_code(&format!("0x{:x}", address),
                                                      &block_number)).unwrap();
                 vm.commit_account(AccountCommitment::Code {
-                    address: address,
+                    address,
                     code: Rc::new(code),
                 }).unwrap();
             },

--- a/cli/src/bin/profiler.rs
+++ b/cli/src/bin/profiler.rs
@@ -19,7 +19,7 @@ impl Profiler {
         let opcode = span.name.to_string();
         match self.occurances.entry(opcode) {
             hash_map::Entry::Occupied(mut entry) => {
-                let (occ, avg) = entry.get().clone();
+                let (occ, avg) = *entry.get();
                 let (nocc, navg) = (occ + 1, ((avg * (occ as f64)) + (span.delta as f64)) / ((occ + 1) as f64));
                 entry.insert((nocc, navg));
             },

--- a/jsontests/jsontests-derive/src/attr.rs
+++ b/jsontests/jsontests-derive/src/attr.rs
@@ -32,7 +32,7 @@ impl Default for ExternalRef {
 
 impl From<String> for ExternalRef {
     fn from(path: String) -> Self {
-        let name = path.rsplit(":").next().unwrap().to_owned();
+        let name = path.rsplit(':').next().unwrap().to_owned();
         ExternalRef {
             path: Ident::from(path),
             name: Ident::from(name)

--- a/jsontests/jsontests-derive/src/lib.rs
+++ b/jsontests/jsontests-derive/src/lib.rs
@@ -36,9 +36,7 @@ pub fn json_tests(input: TokenStream) -> TokenStream {
     };
 
     // Return the generated impl
-    let parsed = gen.parse().unwrap();
-
-    parsed
+    gen.parse().unwrap()
 }
 
 fn impl_json_tests(ast: &syn::DeriveInput) -> Result<quote::Tokens, Error> {
@@ -47,7 +45,7 @@ fn impl_json_tests(ast: &syn::DeriveInput) -> Result<quote::Tokens, Error> {
     let mut tokens = quote::Tokens::new();
 
     // split tests into groups by filepath
-    let tests = tests.into_iter().group_by(|test| test.path.clone());
+    let tests = tests.group_by(|test| test.path.clone());
 
     open_directory_module(&config, &mut tokens);
 
@@ -62,8 +60,8 @@ fn impl_json_tests(ast: &syn::DeriveInput) -> Result<quote::Tokens, Error> {
 
         // Generate test function
         for test in tests {
-            let ref test_func_path = config.test_with.path;
-            let ref test_func_name = config.test_with.name;
+            let test_func_path = &config.test_with.path;
+            let test_func_name = &config.test_with.name;
             let name = sanitize_ident(&test.name);
             let name_ident = Ident::from(name.as_ref());
             let data = json::to_string(&test.data)?;
@@ -85,8 +83,8 @@ fn impl_json_tests(ast: &syn::DeriveInput) -> Result<quote::Tokens, Error> {
 
             // generate optional benchmark body
             if let Some(ref bench) = config.bench_with {
-                let ref bench_func_path = bench.path;
-                let ref bench_func_name = bench.name;
+                let bench_func_path = &bench.path;
+                let bench_func_name = &bench.name;
                 let name = format!("bench_{}", name);
                 let name_ident = Ident::from(name.as_ref());
 

--- a/jsontests/jsontests-derive/src/tests.rs
+++ b/jsontests/jsontests-derive/src/tests.rs
@@ -14,10 +14,10 @@ pub struct Test {
 pub fn read_tests_from_dir<P: AsRef<Path>>(dir_path: P) -> Result<impl Iterator<Item=Test>, Error> {
     let dir = fs::read_dir(dir_path)?;
 
-    let iter = dir.into_iter()
+    let iter = dir
         .flat_map(|file|{
             match file {
-                Ok(file) => tests_iterator_from_direntry(file).unwrap(),
+                Ok(file) => tests_iterator_from_direntry(&file).unwrap(),
                 Err(err) => panic!("failed to read dir: {}", err)
             }
         });
@@ -25,7 +25,7 @@ pub fn read_tests_from_dir<P: AsRef<Path>>(dir_path: P) -> Result<impl Iterator<
     Ok(iter)
 }
 
-pub fn tests_iterator_from_direntry(file: DirEntry) -> Result<impl Iterator<Item=Test>, Error> {
+pub fn tests_iterator_from_direntry(file: &DirEntry) -> Result<impl Iterator<Item=Test>, Error> {
     let path = file.path().to_owned();
     let file = File::open(&path)?;
     let tests: Value = json::from_reader(file)?;

--- a/jsontests/jsontests-derive/src/util.rs
+++ b/jsontests/jsontests-derive/src/util.rs
@@ -5,27 +5,27 @@ use attr::Config;
 
 pub fn open_directory_module(config: &Config, tokens: &mut quote::Tokens) {
     // get the leaf directory name
-    let dirname = config.directory.rsplit("/").next().unwrap();
+    let dirname = config.directory.rsplit('/').next().unwrap();
 
     // create identifier
     let dirname = sanitize_ident(dirname);
     let dirname = Ident::from(dirname);
 
-    open_module(dirname, tokens);
+    open_module(&dirname, tokens);
 }
 
 pub fn open_file_module(filepath: &str, tokens: &mut quote::Tokens) {
     // get file name without extension
-    let filename = filepath.rsplit("/").next().unwrap()
-        .split(".").next().unwrap();
+    let filename = filepath.rsplit('/').next().unwrap()
+        .split('.').next().unwrap();
     // create identifier
     let filename = sanitize_ident(filename);
     let filename = Ident::from(filename);
 
-    open_module(filename, tokens);
+    open_module(&filename, tokens);
 }
 
-pub fn open_module(module_name: Ident, tokens: &mut quote::Tokens) {
+pub fn open_module(module_name: &Ident, tokens: &mut quote::Tokens) {
     // append module opening tokens
     tokens.append(quote! {
         mod #module_name
@@ -49,9 +49,7 @@ pub fn sanitize_ident(ident: &str) -> String {
     } else { ident };
 
     // replace special characters with _
-    let ident = replace_chars(&ident, "!@#$%^&*-+=/<>;\'\"()`~", "_");
-
-    ident
+    replace_chars(&ident, "!@#$%^&*-+=/<>;\'\"()`~", "_")
 }
 
 pub fn replace_chars(s: &str, from: &str, to: &str) -> String {

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -90,13 +90,14 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
     }
 
     /// Deposit code for a ContractCreation transaction or a CREATE opcode.
+    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
     pub fn code_deposit(&mut self) {
         match self.status() {
             MachineStatus::ExitedOk | MachineStatus::ExitedErr(_) => (),
             _ => panic!(),
         }
 
-        if P::code_deposit_limit().is_some() {
+        if P::code_deposit_limit().is_some()  {
             if self.state.out.len() > P::code_deposit_limit().unwrap() {
                 reset_error_hard!(self, OnChainError::EmptyGas);
                 return;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -62,8 +62,8 @@ pub enum GasUsage {
 impl AddAssign<Gas> for GasUsage {
     fn add_assign(&mut self, rhs: Gas) {
         match self {
-            &mut GasUsage::All => (),
-            &mut GasUsage::Some(ref mut gas) => {
+            GasUsage::All => (),
+            GasUsage::Some(ref mut gas) => {
                 *gas = *gas + rhs;
             }
         }
@@ -164,6 +164,7 @@ pub struct Machine<M, P: Patch> {
 
 #[derive(Debug, Clone)]
 /// Represents the current runtime status.
+// TODO: consider boxing the large fields to reduce the total size of the enum
 pub enum MachineStatus {
     /// This runtime is actively running or has just been started.
     Running,
@@ -194,6 +195,7 @@ pub enum ControlCheck {
 
 #[derive(Debug, Clone)]
 /// Used for `step` for additional operations related to the runtime.
+// TODO: consider boxing the large fields to reduce the total size of the enum
 pub enum Control {
     Stop,
     Revert,
@@ -301,7 +303,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Peek the next instruction.
@@ -344,7 +346,7 @@ impl<M: Memory + Default, P: Patch> Machine<M, P> {
         }
 
         match &self.status {
-            &MachineStatus::Running => (),
+            MachineStatus::Running => (),
             _ => panic!(),
         }
 

--- a/src/eval/run/mod.rs
+++ b/src/eval/run/mod.rs
@@ -178,10 +178,10 @@ pub fn run_opcode<M: Memory + Default, P: Patch>(pc: (Instruction, usize), state
         Instruction::DELEGATECALL => { system::delegate_call::<M, P>(state, after_gas) },
         Instruction::STATICCALL => { system::static_call::<M, P>(state, stipend_gas, after_gas) },
         Instruction::RETURN => { pop!(state, start: U256, len: U256);
-                                 state.out = Rc::new(copy_from_memory(&mut state.memory, start, len));
+                                 state.out = Rc::new(copy_from_memory(&state.memory, start, len));
                                  Some(Control::Stop) },
         Instruction::REVERT => { pop!(state, start: U256, len: U256);
-                                 state.out = Rc::new(copy_from_memory(&mut state.memory, start, len));
+                                 state.out = Rc::new(copy_from_memory(&state.memory, start, len));
                                  Some(Control::Revert) },
         Instruction::SUICIDE => { system::suicide(state); Some(Control::Stop) },
     }

--- a/src/eval/run/system.rs
+++ b/src/eval/run/system.rs
@@ -39,8 +39,8 @@ pub fn log<M: Memory + Default, P: Patch>(state: &mut State<M, P>, topic_len: us
 
     state.logs.push(Log {
         address: state.context.address,
-        data: data,
-        topics: topics,
+        data,
+        topics,
     });
 }
 
@@ -83,7 +83,7 @@ pub fn create<M: Memory + Default, P: Patch>(state: &mut State<M, P>, after_gas:
         caller: Some(state.context.address),
         gas_price: state.context.gas_price,
         gas_limit: l64_after_gas,
-        value: value,
+        value,
         input: init,
         action: TransactionAction::Create,
         nonce: state.account_state.nonce(state.context.address).unwrap(),
@@ -111,9 +111,9 @@ pub fn call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipend_gas:
     let transaction = ValidTransaction {
         caller: Some(state.context.address),
         gas_price: state.context.gas_price,
-        gas_limit: gas_limit,
-        value: value,
-        input: input,
+        gas_limit,
+        value,
+        input,
         action: TransactionAction::Call(to),
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
@@ -143,9 +143,9 @@ pub fn static_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, stipe
     let transaction = ValidTransaction {
         caller: Some(state.context.address),
         gas_price: state.context.gas_price,
-        gas_limit: gas_limit,
+        gas_limit,
         value: U256::zero(),
-        input: input,
+        input,
         action: TransactionAction::Call(to),
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };
@@ -172,9 +172,9 @@ pub fn delegate_call<M: Memory + Default, P: Patch>(state: &mut State<M, P>, aft
     let transaction = ValidTransaction {
         caller: Some(state.context.caller),
         gas_price: state.context.gas_price,
-        gas_limit: gas_limit,
+        gas_limit,
         value: state.context.value,
-        input: input,
+        input,
         action: TransactionAction::Call(to),
         nonce: state.account_state.nonce(state.context.address).unwrap(),
     };

--- a/src/eval/util.rs
+++ b/src/eval/util.rs
@@ -57,6 +57,6 @@ pub fn copy_into_memory_apply<M: Memory>(memory: &mut M, values: &[u8], start: U
     while i < start + actual_len {
         memory.write_raw(i, values[j]).unwrap();
         i = i + U256::from(1u64);
-        j = j + 1;
+        j += 1;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,6 +329,7 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
         Ok(())
     }
 
+    #[cfg_attr(feature = "cargo-clippy", allow(single_match))]
     fn status(&self) -> VMStatus {
         match self.machines.last().unwrap().status().clone() {
             MachineStatus::ExitedNotSupported(err) => return VMStatus::ExitedNotSupported(err),
@@ -338,7 +339,7 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
         match self.machines[0].status() {
             MachineStatus::Running | MachineStatus::InvokeCreate(_) | MachineStatus::InvokeCall(_, _) => VMStatus::Running,
             MachineStatus::ExitedOk => VMStatus::ExitedOk,
-            MachineStatus::ExitedErr(err) => VMStatus::ExitedErr(err.into()),
+            MachineStatus::ExitedErr(err) => VMStatus::ExitedErr(err),
             MachineStatus::ExitedNotSupported(err) => VMStatus::ExitedNotSupported(err),
         }
     }
@@ -375,7 +376,7 @@ impl<M: Memory + Default, P: Patch> VM for ContextVM<M, P> {
                 Ok(())
             },
             MachineStatus::ExitedOk | MachineStatus::ExitedErr(_) => {
-                if self.machines.len() == 0 {
+                if self.machines.is_empty() {
                     panic!()
                 } else if self.machines.len() == 1 {
                     Ok(())

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -51,9 +51,14 @@ impl<P: Patch> Default for SeqMemory<P> {
 
 impl<P: Patch> SeqMemory<P> {
     /// Get the length of the current effective memory range.
+    #[inline]
     pub fn len(&self) -> usize {
         self.memory.len()
     }
+
+    /// Return true if current effective memory range is zero
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 impl<P: Patch> Memory for SeqMemory<P> {
@@ -108,9 +113,10 @@ impl<P: Patch> Memory for SeqMemory<P> {
     fn read(&self, index: U256) -> M256 {
         let mut a: [u8; 32] = [0u8; 32];
 
-        for i in 0..32 {
-            a[i] = self.read_raw(index + i.into());
+        for (i, item) in a[0..32].iter_mut().enumerate() {
+            *item = self.read_raw(index + i.into());
         }
+
         a.as_ref().into()
     }
 

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -48,13 +48,13 @@ impl Valids {
             match opcode {
                 Opcode::JUMPDEST => {
                     valids[i] = true;
-                    i = i + 1;
+                    i += 1;
                 },
                 Opcode::PUSH(v) => {
-                    i = i + v + 1;
+                    i += v + 1;
                 },
                 _ => {
-                    i = i + 1;
+                    i += 1;
                 }
             }
         }
@@ -64,7 +64,12 @@ impl Valids {
 
     /// Get the length of the valid mapping. This is the same as the
     /// code bytes.
+    #[inline]
     pub fn len(&self) -> usize { self.0.len() }
+
+    /// Returns true if the valids list is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 
     /// Returns `true` if the position is a valid jump destination. If
     /// not, returns `false`.
@@ -77,7 +82,7 @@ impl Valids {
             return false;
         }
 
-        return true;
+        true
     }
 }
 
@@ -129,13 +134,13 @@ macro_rules! impl_pc {
                     let opcode: Opcode = self.code[i].into();
                     match opcode {
                         Opcode::PUSH(v) => {
-                            i = i + v + 1;
+                            i += v + 1;
                         },
                         _ => {
-                            i = i + 1;
+                            i += 1;
                         }
                     }
-                    o = o + 1;
+                    o += 1;
                 }
                 o
             }
@@ -330,7 +335,7 @@ impl<'a, P: Patch> PCMut<'a, P> {
                 *self.position = min(*self.position + v + 1, self.code.len());
             },
             _ => {
-                *self.position = *self.position + 1;
+                *self.position += 1;
             },
         }
         Ok(result)

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -77,7 +77,12 @@ impl Stack {
     }
 
     /// Get the current stack length.
+    #[inline]
     pub fn len(&self) -> usize {
         self.stack.len()
     }
+
+    /// Returns true if stack is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -84,18 +84,18 @@ impl UntrustedTransaction {
                 caller: Some(address),
                 gas_price: self.gas_price,
                 gas_limit: self.gas_limit,
-                action: self.action.clone(),
+                action: self.action,
                 value: self.value,
                 input: self.input.clone(),
-                nonce: nonce,
+                nonce,
             }
         };
 
         if valid.gas_limit < valid.intrinsic_gas::<P>() {
-            return Err(PreExecutionError::InsufficientGasLimit);
+            Err(PreExecutionError::InsufficientGasLimit)
+        } else {
+            Ok(valid)
         }
-
-        return Ok(valid);
     }
 }
 
@@ -153,10 +153,10 @@ impl ValidTransaction {
             caller: Some(caller),
             gas_price: transaction.gas_price,
             gas_limit: transaction.gas_limit,
-            action: transaction.action.clone(),
+            action: transaction.action,
             value: transaction.value,
             input: Rc::new(transaction.input.clone()),
-            nonce: nonce,
+            nonce,
         };
 
         if valid.gas_limit < valid.intrinsic_gas::<P>() {
@@ -192,9 +192,11 @@ impl ValidTransaction {
     /// execution.
     pub fn intrinsic_gas<P: Patch>(&self) -> Gas {
         let mut gas = Gas::from(G_TRANSACTION);
+
         if self.action == TransactionAction::Create {
-            gas = gas + Gas::from(P::gas_transaction_create());
+            gas = gas + P::gas_transaction_create();
         }
+
         for d in self.input.deref() {
             if *d == 0 {
                 gas = gas + Gas::from(G_TXDATAZERO);
@@ -202,7 +204,8 @@ impl ValidTransaction {
                 gas = gas + Gas::from(G_TXDATANONZERO);
             }
         }
-        return gas;
+
+        gas
     }
 
     /// Convert this transaction into a context. Note that this will
@@ -298,8 +301,7 @@ impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
         let valid = transaction.to_valid::<P>()?;
         let mut vm = TransactionVM(TransactionVMState::Constructing {
             transaction: valid,
-            block: block,
-
+            block,
             account_state: AccountState::default(),
             blockhash_state: BlockhashState::default(),
         });
@@ -311,9 +313,8 @@ impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
     /// patch. This VM runs at the transaction level.
     pub fn new(transaction: ValidTransaction, block: HeaderParams) -> Self {
         TransactionVM(TransactionVMState::Constructing {
-            transaction: transaction,
-            block: block,
-
+            transaction,
+            block,
             account_state: AccountState::default(),
             blockhash_state: BlockhashState::default(),
         })
@@ -325,9 +326,8 @@ impl<M: Memory + Default, P: Patch> TransactionVM<M, P> {
         transaction: ValidTransaction, block: HeaderParams, vm: &TransactionVM<M, P>
     ) -> Self {
         TransactionVM(TransactionVMState::Constructing {
-            transaction: transaction,
-            block: block,
-
+            transaction,
+            block,
             account_state: match vm.0 {
                 TransactionVMState::Constructing { ref account_state, .. } =>
                     account_state.clone(),

--- a/stateful/examples/parallel.rs
+++ b/stateful/examples/parallel.rs
@@ -184,7 +184,7 @@ pub fn parallel_execute(
 
         threads.push(thread::spawn(move || {
             let vm: SeqTransactionVM<MainnetEIP160Patch> = stateful.call(
-                transaction.into(), header, &[]);
+                transaction.into(), &header, &[]);
             let accounts: Vec<SendableAccountChange> = vm.accounts().map(|v| SendableAccountChange::from(v.clone())).collect();
             (accounts, vm.used_addresses())
         }));
@@ -210,7 +210,7 @@ pub fn parallel_execute(
             // Re-execute the transaction if conflict is detected.
             println!("Transaction index {}: conflict detected, re-execute.", index);
             let vm: SeqTransactionVM<MainnetEIP160Patch> = stateful.call(
-                transactions[index].clone(), header.clone(), &[]);
+                transactions[index].clone(), &header, &[]);
             let accounts: Vec<AccountChange> = vm.accounts().map(|v| v.clone()).collect();
             (accounts, vm.used_addresses())
         } else {

--- a/stateful/tests/genesis.rs
+++ b/stateful/tests/genesis.rs
@@ -102,7 +102,7 @@ fn genesis_state_root() {
             value: balance,
             input: empty_input.clone(),
             nonce: U256::zero(),
-        }, HeaderParams {
+        }, &HeaderParams {
             beneficiary: Address::default(),
             timestamp: 0,
             number: U256::zero(),


### PR DESCRIPTION
This PR proposes changes based on 100+ clippy linter warnings.

Mostly style fixes but also some possible bugs such as lossy integer conversions, identical if branches and cloning a double-reference.

There are still unfixed warnings left, but working around these would require thorough benchmarking in order to identify how exactly the change proposed by clippy would impact the performance.