### PR TITLE
Fix no-std builds and rust-secp256k1 feature

### DIFF
--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -7,5 +7,12 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -7,7 +7,14 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128" }
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp" }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1", "sputnikvm-precompiled-bn128/c-secp256k1", "sputnikvm-precompiled-modexp/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1", "sputnikvm-precompiled-bn128/rust-secp256k1", "sputnikvm-precompiled-modexp/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -7,7 +7,14 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128" }
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp" }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1", "sputnikvm-precompiled-bn128/c-secp256k1", "sputnikvm-precompiled-modexp/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1", "sputnikvm-precompiled-bn128/rust-secp256k1", "sputnikvm-precompiled-modexp/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -7,5 +7,14 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1", "sputnikvm-precompiled-bn128/c-secp256k1", "sputnikvm-precompiled-modexp/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1", "sputnikvm-precompiled-bn128/rust-secp256k1", "sputnikvm-precompiled-modexp/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -7,5 +7,14 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1", "sputnikvm-precompiled-bn128/c-secp256k1", "sputnikvm-precompiled-modexp/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1", "sputnikvm-precompiled-bn128/rust-secp256k1", "sputnikvm-precompiled-modexp/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -7,6 +7,13 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 bn-plus = { version = "0.4" }
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/precompiled/modexp/Cargo.toml
+++ b/precompiled/modexp/Cargo.toml
@@ -7,9 +7,16 @@ authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
-sputnikvm = { version = "0.10", path = "../.." }
+sputnikvm = { version = "0.10", path = "../..", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 num-bigint = "0.1"
 
 [dev-dependencies]
 etcommon-hexutil = "0.2"
+
+[features]
+default = ["std", "c-secp256k1"]
+rlp = ["etcommon-bigint/rlp"]
+c-secp256k1 = ["sputnikvm/c-secp256k1"]
+rust-secp256k1 = ["sputnikvm/rust-secp256k1"]
+std = ["sputnikvm/std"]

--- a/src/commit/account.rs
+++ b/src/commit/account.rs
@@ -1,11 +1,11 @@
 //! Account commitment managment
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(feature = "std")] use std::collections::{HashSet as Set, HashMap as Map, hash_map as map};
 #[cfg(feature = "std")] use std::marker::PhantomData;
-#[cfg(not(feature = "std"))] use alloc::{BTreeSet as Set, BTreeMap as Map, btree_map as map};
+#[cfg(not(feature = "std"))] use alloc::{collections::BTreeSet as Set, collections::BTreeMap as Map, collections::btree_map as map};
 #[cfg(not(feature = "std"))] use core::marker::PhantomData;
 use bigint::{M256, U256, Address};
 use patch::AccountPatch;

--- a/src/commit/blockhash.rs
+++ b/src/commit/blockhash.rs
@@ -1,7 +1,7 @@
 //! Blockhash commitment management
 
 #[cfg(feature = "std")] use std::collections::HashMap as Map;
-#[cfg(not(feature = "std"))] use alloc::BTreeMap as Map;
+#[cfg(not(feature = "std"))] use alloc::collections::BTreeMap as Map;
 use bigint::{U256, H256};
 
 use errors::{RequireError, CommitError};

--- a/src/eval/lifecycle.rs
+++ b/src/eval/lifecycle.rs
@@ -1,7 +1,7 @@
 //! Runtime lifecycle related functionality.
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
 #[cfg(feature = "std")] use std::rc::Rc;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -1,9 +1,10 @@
 //! VM Runtime
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
+#[cfg(not(feature = "std"))] use alloc::boxed::Box;
 #[cfg(feature = "std")] use std::rc::Rc;
 
 #[cfg(not(feature = "std"))] use core::ops::AddAssign;

--- a/src/eval/run/system.rs
+++ b/src/eval/run/system.rs
@@ -1,7 +1,7 @@
 //! System operations instructions
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
 #[cfg(feature = "std")] use std::rc::Rc;

--- a/src/eval/util.rs
+++ b/src/eval/util.rs
@@ -1,7 +1,7 @@
 //! Eval utilities
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use bigint::{U256, M256, Gas};
 use ::Memory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,11 @@ pub use self::util::opcode::Opcode;
 pub use block_core::TransactionAction;
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(feature = "std")] use std::collections::{HashSet as Set, hash_map as map};
-#[cfg(not(feature = "std"))] use alloc::{BTreeSet as Set, btree_map as map};
+#[cfg(not(feature = "std"))] use alloc::{collections::BTreeSet as Set, collections::btree_map as map};
+#[cfg(not(feature = "std"))] use alloc::boxed::Box;
 #[cfg(feature = "std")] use std::cmp::min;
 #[cfg(not(feature = "std"))] use core::cmp::min;
 use bigint::{U256, H256, Gas, Address};

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,7 +1,7 @@
 //! VM memory representation
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use bigint::{U256, M256};
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,7 +1,7 @@
 //! Parameters used by the VM.
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
 #[cfg(feature = "std")] use std::rc::Rc;

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
 #[cfg(feature = "std")] use std::rc::Rc;

--- a/src/pc.rs
+++ b/src/pc.rs
@@ -1,7 +1,7 @@
 //! EVM Program Counter.
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use bigint::M256;
 use util::opcode::Opcode;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,7 +1,7 @@
 //! EVM stack
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use bigint::M256;
 use super::errors::OnChainError;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,7 +1,7 @@
 //! Transaction related functionality.
 
 #[cfg(not(feature = "std"))]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))] use alloc::rc::Rc;
 #[cfg(feature = "std")] use std::rc::Rc;
@@ -9,7 +9,7 @@ use alloc::Vec;
 #[cfg(feature = "std")] use std::collections::{HashSet as Set, hash_map as map};
 #[cfg(feature = "std")] use std::cmp::min;
 #[cfg(feature = "std")] use std::ops::Deref;
-#[cfg(not(feature = "std"))] use alloc::{BTreeSet as Set, btree_map as map};
+#[cfg(not(feature = "std"))] use alloc::{collections::BTreeSet as Set, collections::btree_map as map};
 #[cfg(not(feature = "std"))] use core::cmp::min;
 #[cfg(not(feature = "std"))] use core::ops::Deref;
 use bigint::{U256, H256, Address, Gas};


### PR DESCRIPTION
Two main changes in this PR:

1) correct handling of `SputnikVM` feature passing in precompiled contracts and network crates
2) correct includes of no-std `alloc` crate members (changed since nightly 1.17 (?))

Closes #340