### PR TITLE
Bump network and precompiled crates minor versions

### DIFF
--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-classic"
-version = "0.10.0"
+version = "0.10.1"
 description = "Ethereum Classic patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-ellaism"
-version = "0.10.0"
+version = "0.10.1"
 description = "Ellaism patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-expanse"
-version = "0.10.0"
+version = "0.10.1"
 description = "Expanse patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10.1", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10.1", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-foundation"
-version = "0.10.0"
+version = "0.10.1"
 description = "Ethereum patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10.1", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10.1", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10.1", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10.1", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-musicoin"
-version = "0.10.0"
+version = "0.10.1"
 description = "Musicoin patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-network-ubiq"
-version = "0.10.0"
+version = "0.10.1"
 description = "Ubiq patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/ethereumproject/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }
-sputnikvm-precompiled-bn128 = { version = "0.10", path = "../../precompiled/bn128", default-features = false}
-sputnikvm-precompiled-modexp = { version = "0.10", path = "../../precompiled/modexp", default-features = false }
+sputnikvm-precompiled-bn128 = { version = "0.10.1", path = "../../precompiled/bn128", default-features = false}
+sputnikvm-precompiled-modexp = { version = "0.10.1", path = "../../precompiled/modexp", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-precompiled-bn128"
-version = "0.10.0"
+version = "0.10.1"
 description = "bn128 precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]

--- a/precompiled/modexp/Cargo.toml
+++ b/precompiled/modexp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sputnikvm-precompiled-modexp"
-version = "0.10.0"
+version = "0.10.1"
 description = "modexp precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]


### PR DESCRIPTION
Pretty self-explanatory. Need bumped versions on crates.io.

Default features are configured in the way it shouldn't affect current builds with `sputnikvm-ffi`, hence the minor version bump.