### PR TITLE
Relax semver rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ etcommon-rlp = { version = "0.2", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false, features = ["rlp"] }
 
 etcommon-block = { version = "0.3", default-features = false, optional = true }
-secp256k1-plus = { version = "0.5.7", optional = true }
+secp256k1-plus = { version = "0.5", optional = true }
 libsecp256k1 = { version = "0.1", optional = true }
-log = "0.4.3"
+log = "0.4"
 
 [dev-dependencies]
 etcommon-hexutil = "0.2"


### PR DESCRIPTION
Strict sub-versioning can cause build errors when client crate is using another subversion of the crate.