### PR TITLE
Fixing the travis badge and github links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 keywords = ["no_std", "ethereum"]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SputnikVM: A Blockchain Virtual Machine
 
-[![Build Status](https://travis-ci.org/ethereumproject/sputnikvm.svg?branch=master)](https://travis-ci.org/ethereumproject/sputnikvm)
+[![Build Status](https://travis-ci.org/ETCDEVTeam/sputnikvm.svg?branch=master)](https://travis-ci.org/ETCDEVTeam/sputnikvm)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 
 | Name               | Description                                   | Crates.io                                                                                                           | Documentation                                                                                        |
@@ -48,11 +48,11 @@ The core library has the initial four precompiled contracts embedded. To use the
 
 ## Related projects
 
- * [SputnikVM Dev](https://github.com/ethereumproject/sputnikvm-dev) - SputnikVM instance for Smart Contract development, 
+ * [SputnikVM Dev](https://github.com/ETCDEVTeam/sputnikvm-dev) - SputnikVM instance for Smart Contract development, 
     provides testing environment and mock for JSON RPC API
- * [SputnikVM in Browser](https://github.com/ethereumproject/sputnikvm-in-browser) - experimental version of SputnikVM 
+ * [SputnikVM in Browser](https://github.com/sorpaas/sputnikvm-in-browser) - experimental version of SputnikVM 
     compiled into WebAssembly, therefore can be launched in a browser on Node.js
- * [SputnikVM for embedded devices](https://github.com/ethereumproject/sputnikvm-on-rux) - experimental project to run on 
+ * [SputnikVM for embedded devices](https://github.com/sorpaas/sputnikvm-on-rux) - experimental project to run on 
     full functional EVM on embedded devices       
 
 ## Dependencies
@@ -77,7 +77,7 @@ To start working with SputnikVM you'll
 need to install [rustup](https://www.rustup.rs/), then you can do:
  
 ```bash
-$ git clone git@github.com:ethereumproject/sputnikvm.git
+$ git clone git@github.com:ETCDEVTeam/sputnikvm.git
 $ cd sputnikvm
 $ cargo build --release --all
 ```
@@ -88,18 +88,18 @@ We currently use two ways to test SputnikVM and ensure its execution
 aligns with other Ethereum Virtual Machine implementations:
 
 * [jsontests](/jsontests): This uses part of the Ethereum
-  [tests](https://github.com/ethereumproject/tests). Those tests
+  [tests](https://github.com/ETCDEVTeam/tests). Those tests
   currently does not have good coverage for system operation
   opcodes. Besides, some tests are incorrect so they are disabled.
 * [regtests](/regtests): A complete regression tests is done on the
   Ethereum Classic mainnet from genesis block to block 4 million. Some
   of the previously failed tests are also integrated into Rust's test
   system. See
-  [wiki](https://github.com/ethereumproject/sputnikvm/wiki/Building-and-Testing)
+  [wiki](https://github.com/ETCDEVTeam/sputnikvm/wiki/Building-and-Testing)
   for how to reproduce the regression tests.
   
 To learn more about building SputnikVM from source please read wiki page
- [Building and Testing](https://github.com/ethereumproject/sputnikvm/wiki/Building-and-Testing)  
+ [Building and Testing](https://github.com/ETCDEVTeam/sputnikvm/wiki/Building-and-Testing)  
 
 ## License
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM CLI"
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 # Since we have an explicit [[bin]] section below, we add the
 # following "autobins" line to prevent Cargo from automatically

--- a/gethrpc/Cargo.toml
+++ b/gethrpc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "gethrpc - provides functionality for interacting with geth's blockchain."
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 clap = "2.22"

--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Ethereum Classic patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Ellaism patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Expanse patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Ethereum patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Musicoin patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "Ubiq patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "bn128 precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }

--- a/precompiled/modexp/Cargo.toml
+++ b/precompiled/modexp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.10.1"
 description = "modexp precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/ethereumproject/sputnikvm"
+repository = "https://github.com/ETCDEVTeam/sputnikvm"
 
 [dependencies]
 sputnikvm = { version = "0.10", path = "../..", default-features = false }


### PR DESCRIPTION
Hi,
Just a simple change on most links from `ethereumproject` to `ETCDEVTeam`.
in some cases the repos are actually at `sorpaas`'s repo, so I pointed there.