### PR TITLE
Allow CI failures on beta channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
 matrix:
   allow_failures:
     - rust: nightly
+    - rust: beta
 
 before_deploy:
   - sh .ci/before_deploy.sh


### PR DESCRIPTION
Currently beta lifetime checker have a stable-to-beta regression. We should allow CI failing on beta in sputnikvm-stateful until the https://github.com/rust-lang/rust/issues/55756 issue is resolved in rustc repo